### PR TITLE
Bug Fixes for PresentationBuilder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
   build:
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         dotnet: [3.1.302]

--- a/OpenXmlPowerTools.Tests/PowerPoint/OpenXmlExtensions.cs
+++ b/OpenXmlPowerTools.Tests/PowerPoint/OpenXmlExtensions.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Tests.PowerPoint
+{
+    public static class OpenXmlExtensions
+    {
+        public static PresentationDocument OpenPresentation(Stream stream, bool isEditable, OpenSettings openSettings)
+        {
+            try
+            {
+                return PresentationDocument.Open(stream, isEditable, openSettings);
+            }
+            catch (OpenXmlPackageException e)
+            {
+                if (!e.ToString().Contains("Invalid Hyperlink"))
+                    throw;
+
+                FixInvalidUri(stream);
+                return PresentationDocument.Open(stream, isEditable, openSettings);
+            }
+        }
+
+        // http://ericwhite.com/blog/handling-invalid-hyperlinks-openxmlpackageexception-in-the-open-xml-sdk/
+        private static void FixInvalidUri(Stream fs)
+        {
+            var uriPlaceholder = "https://invalid.uri.com";
+
+            XNamespace relNs = "http://schemas.openxmlformats.org/package/2006/relationships";
+            using var za = new ZipArchive(fs, ZipArchiveMode.Update, leaveOpen: true);
+            foreach (var entry in za.Entries.ToList())
+            {
+                if (!entry.Name.EndsWith(".rels"))
+                    continue;
+                var replaceEntry = false;
+                XDocument entryXDoc = null;
+                using (var entryStream = entry.Open())
+                {
+                    try
+                    {
+                        entryXDoc = XDocument.Load(entryStream);
+                        if (entryXDoc.Root?.Name.Namespace == relNs)
+                        {
+                            var urisToCheck = entryXDoc
+                                .Descendants(relNs + "Relationship")
+                                .Where(r => r.Attribute("TargetMode")?.Value == "External");
+                            foreach (var rel in urisToCheck)
+                            {
+                                if (rel.Attribute("Target") is {} attr)
+                                {
+                                    try
+                                    {
+                                        var _ = new Uri(attr.Value);
+                                    }
+                                    catch (UriFormatException)
+                                    {
+                                        attr.Value = uriPlaceholder;
+                                        replaceEntry = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch (XmlException)
+                    {
+                        continue;
+                    }
+                }
+                if (replaceEntry)
+                {
+                    var fullName = entry.FullName;
+                    entry.Delete();
+                    var newEntry = za.CreateEntry(fullName);
+                    using var writer = new StreamWriter(newEntry.Open());
+                    using var xmlWriter = XmlWriter.Create(writer);
+                    entryXDoc.WriteTo(xmlWriter);
+                }
+            }
+        }
+    }
+}

--- a/OpenXmlPowerTools.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.cs
+++ b/OpenXmlPowerTools.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.cs
@@ -34,19 +34,15 @@ namespace Clippit.Tests.PowerPoint
                 Directory.Delete(targetDir, true);
             Directory.CreateDirectory(targetDir);
 
-            var document = new PmlDocument(sourcePath);
+            using var srcStream = File.Open(sourcePath, FileMode.Open);
+            var openSettings = new OpenSettings {AutoSave = false};
+            using var srcDoc = OpenXmlExtensions.OpenPresentation(srcStream, false, openSettings);
 
-            string title;
-            DateTime? modified;
-            using (var streamDoc = new OpenXmlMemoryStreamDocument(document))
-            {
-                using var srcDoc = streamDoc.GetPresentationDocument(new OpenSettings { AutoSave = false });
-                title = srcDoc.PackageProperties.Title;
-                modified = srcDoc.PackageProperties.Modified;
-            }
+            var title = srcDoc.PackageProperties.Title;
+            var modified = srcDoc.PackageProperties.Modified;
 
             var sameTitle = 0;
-            foreach (var slide in PresentationBuilder.PublishSlides(document))
+            foreach (var slide in PresentationBuilder.PublishSlides(srcDoc, sourcePath))
             {
                 slide.SaveAs(Path.Combine(targetDir, Path.GetFileName(slide.FileName)));
 

--- a/OpenXmlPowerTools.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.cs
+++ b/OpenXmlPowerTools.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.cs
@@ -38,7 +38,7 @@ namespace Clippit.Tests.PowerPoint
             var openSettings = new OpenSettings {AutoSave = false};
             using var srcDoc = OpenXmlExtensions.OpenPresentation(srcStream, false, openSettings);
 
-            var title = srcDoc.PackageProperties.Title;
+            var title = srcDoc.PackageProperties.Title ?? string.Empty;
             var modified = srcDoc.PackageProperties.Modified;
 
             var sameTitle = 0;

--- a/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
@@ -1367,10 +1367,13 @@ namespace Clippit.PowerPoint
                 }
                 else
                 {
-                    var fromPart = newContentPart.OpenXmlPackage.Package.GetParts().FirstOrDefault(p => p.Uri == newContentPart.Uri);
-                    fromPart?.CreateRelationship(new Uri("NULL", UriKind.RelativeOrAbsolute),
-                        System.IO.Packaging.TargetMode.Internal,
-                        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image", relId);
+                    var newPart = newContentPart.OpenXmlPackage.Package.GetParts().FirstOrDefault(p => p.Uri == newContentPart.Uri);
+                    if (newPart?.RelationshipExists(relId) == false)
+                    {
+                        newPart.CreateRelationship(new Uri("NULL", UriKind.RelativeOrAbsolute),
+                            System.IO.Packaging.TargetMode.Internal,
+                            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image", relId);
+                    }
                 }
             }
         }

--- a/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
@@ -579,11 +579,11 @@ namespace Clippit.PowerPoint
         {
             // Search for existing master slide with same theme name
             XDocument oldTheme = sourceMasterPart.ThemePart.GetXDocument();
-            var themeName = oldTheme.Root.Attribute(NoNamespace.name).Value;
+            var themeName = oldTheme.Root.Attribute(NoNamespace.name)?.Value ?? "noname";
             foreach (var master in newDocument.PresentationPart.GetPartsOfType<SlideMasterPart>())
             {
                 var themeDoc = master.ThemePart.GetXDocument();
-                if (themeDoc.Root.Attribute(NoNamespace.name).Value == themeName)
+                if (themeDoc.Root.Attribute(NoNamespace.name)?.Value == themeName)
                     return master;
             }
 
@@ -621,7 +621,7 @@ namespace Clippit.PowerPoint
                 {
                     var newThemeName = $"{themeName}:{layoutName}";
                     oldTheme = new XDocument(oldTheme);
-                    oldTheme.Root.Attribute(NoNamespace.name).SetValue(newThemeName);
+                    oldTheme.Root.SetAttributeValue(NoNamespace.name, newThemeName);
                 }
             }
 

--- a/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
@@ -85,8 +85,12 @@ namespace Clippit.PowerPoint
         public static IEnumerable<PmlDocument> PublishSlides(PmlDocument src)
         {
             using var streamSrcDoc = new OpenXmlMemoryStreamDocument(src);
-            using var srcDoc = streamSrcDoc.GetPresentationDocument(new OpenSettings { AutoSave = false});
+            using var srcDoc = streamSrcDoc.GetPresentationDocument(new OpenSettings {AutoSave = false});
+            return PublishSlides(srcDoc, src.FileName);
+        }
 
+        public static IEnumerable<PmlDocument> PublishSlides(PresentationDocument srcDoc, string fileName)
+        {
             var slideList = srcDoc.PresentationPart.GetXDocument().Root.Descendants(P.sldId).ToList();
             for (var slideNumber = 0; slideNumber < slideList.Count; slideNumber++)
             {
@@ -102,7 +106,7 @@ namespace Clippit.PowerPoint
                 output.Close();
 
                 var slideDoc = streamDoc.GetModifiedPmlDocument();
-                if (src.FileName is {} fileName)
+                if (!string.IsNullOrWhiteSpace(fileName))
                 {
                     slideDoc.FileName = fileName.Replace(".pptx", $"_{slideNumber + 1:000}.pptx");
                 }

--- a/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
@@ -82,11 +82,11 @@ namespace Clippit.PowerPoint
             return streamDoc.GetModifiedPmlDocument();
         }
 
-        public static IEnumerable<PmlDocument> PublishSlides(PmlDocument src)
+        public static IList<PmlDocument> PublishSlides(PmlDocument src)
         {
             using var streamSrcDoc = new OpenXmlMemoryStreamDocument(src);
             using var srcDoc = streamSrcDoc.GetPresentationDocument(new OpenSettings {AutoSave = false});
-            return PublishSlides(srcDoc, src.FileName);
+            return PublishSlides(srcDoc, src.FileName).ToList();
         }
 
         public static IEnumerable<PmlDocument> PublishSlides(PresentationDocument srcDoc, string fileName)

--- a/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
@@ -546,7 +546,8 @@ namespace Clippit.PowerPoint
                     NotesSlidePart newPart = newSlide.AddNewPart<NotesSlidePart>();
                     newPart.PutXDocument(notesSlide.GetXDocument());
                     newPart.AddPart(newSlide);
-                    newPart.AddPart(newDocument.PresentationPart.NotesMasterPart);
+                    if (newDocument.PresentationPart.NotesMasterPart is {})
+                        newPart.AddPart(newDocument.PresentationPart.NotesMasterPart);
                     AddRelationships(notesSlide, newPart, new[] { newPart.GetXDocument().Root });
                     CopyRelatedPartsForContentParts(newDocument, slide.NotesSlidePart, newPart, new[] { newPart.GetXDocument().Root }, images, mediaList);
                 }

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 1.2.3 - July 22, 2020
+#### 1.3.0 - July 29, 2020
 - DocumentFormat.OpenXml (2.11.3)
+- Bug Fixes for PresentationBuilder [#16](https://github.com/sergey-tihon/Clippit/pull/16)
 
 #### 1.2.1 - May 2, 2020
 - HTML to WML: Allow font-size with unit rem [#13](https://github.com/sergey-tihon/Clippit/pull/13)


### PR DESCRIPTION
Known errors:
- [x] Invalid Hyperlink: Malformed URI is embedded as a hyperlink in the document
- [x] System.ArgumentNullException : Value cannot be null. (Parameter 'subPart')
- [x] System.ArgumentOutOfRangeException : Specified argument was out of the range of valid values. (Parameter 'id')
- [x] System.Xml.XmlException : 'if' is an unexpected token. The expected token is 'CDATA['. Line 15, position 6.
- [x] System.Xml.XmlException : 'css' is an undeclared prefix. Line 30, position 13.
- [x] System.Xml.XmlException : 'w' is an undeclared prefix. Line 46, position 4.
- [x] System.Xml.XmlException : 'rId6' ID conflicts with the ID of an existing relationship for the specified source.
- [x] System.Xml.XmlException : 'R2500d220ef7c476a' ID conflicts with the ID of an existing relationship for the specified source.
- [x] System.NullReferenceException : Object reference not set to an instance of an object.