### PR TITLE
Resolving bug with nested rowspans

### DIFF
--- a/OpenXmlPowerTools.Tests/Word/HtmlConverterTests.cs
+++ b/OpenXmlPowerTools.Tests/Word/HtmlConverterTests.cs
@@ -130,29 +130,6 @@ namespace Clippit.Tests.Word
             ConvertToHtmlNoCssClasses(sourceDocx, oxPtConvertedDestHtml);
         }
 
-        [Fact]
-        public void MyTest()
-        {
-            DirectoryInfo sourceDir = new DirectoryInfo("../../../../TestFiles/");
-            var htmlString = File.ReadAllText(Path.Combine(sourceDir.FullName, "T1880.html"));
-            var processedDestDocx = new FileInfo(Path.Combine(TempDir, "T1880.html-processed-by-DocumentBuilder.docx"));
-
-            XElement html = HtmlToWmlReadAsXElement.ReadAsXElement(htmlString);
-
-            string usedAuthorCss = HtmlToWmlConverter.CleanUpCss((string)html.Descendants().FirstOrDefault(d => d.Name.LocalName.ToLower() == "style"));
-
-            HtmlToWmlConverterSettings settings = HtmlToWmlConverter.GetDefaultSettings();
-
-            WmlDocument doc = HtmlToWmlConverter.ConvertHtmlToWml(string.Empty, usedAuthorCss, string.Empty, html, settings);
-
-            var sources = new List<ISource>
-            {
-                new Source(doc, true),
-            };
-
-            DocumentBuilder.BuildDocument(sources, processedDestDocx.FullName);
-        }
-
         private static void CopyFormattingAssembledDocx(FileInfo source, FileInfo dest)
         {
             var ba = File.ReadAllBytes(source.FullName);
@@ -410,46 +387,6 @@ namespace Clippit.Tests.Word
 #endif
     }
 
-    public static class HtmlToWmlReadAsXElement
-    {
-        public static XElement ReadAsXElement(string htmlString)
-        {
-            XElement html = null;
-            try
-            {
-                html = XElement.Parse(htmlString);
-            }
-            catch (XmlException)
-            {
-                htmlString.Replace("&amp;", "&");
-                htmlString.Replace("&nbsp;", "\xA0");
-                htmlString.Replace("&quot;", "\"");
-                htmlString.Replace("&lt;", "~lt;");
-                htmlString.Replace("&gt;", "~gt;");
-                htmlString.Replace("&#", "~#");
-                htmlString.Replace("&", "&amp;");
-                htmlString.Replace("~lt;", "&lt;");
-                htmlString.Replace("~gt;", "&gt;");
-                htmlString.Replace("~#", "&#");
-                html = XElement.Parse(htmlString);
-            }
-            // HtmlToWmlConverter expects the HTML elements to be in no namespace, so convert all elements to no namespace.
-            html = (XElement)ConvertToNoNamespace(html);
-            return html;
-        }
-
-        private static object ConvertToNoNamespace(XNode node)
-        {
-            XElement element = node as XElement;
-            if (element != null)
-            {
-                return new XElement(element.Name.LocalName,
-                    element.Attributes().Where(a => !a.IsNamespaceDeclaration),
-                    element.Nodes().Select(n => ConvertToNoNamespace(n)));
-            }
-            return node;
-        }
-    }
 }
 
 #endif

--- a/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
+++ b/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
@@ -240,6 +240,11 @@ namespace Clippit.HtmlToWml
                             .Elements(XhtmlNoNamespace.td)
                             .Skip(colNumber - 1)
                             .FirstOrDefault();
+                        if (tdToAddAfter == null)
+                        {
+                            tdToAddAfter = rowsToAddTo.Elements(XhtmlNoNamespace.td)
+                                .LastOrDefault();
+                        }
                         var td = new XElement(XhtmlNoNamespace.td,
                             rowSpanCell.Attributes(),
                             new XAttribute("HtmlToWmlVMergeNoRestart", "true"));

--- a/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
+++ b/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
@@ -242,7 +242,7 @@ namespace Clippit.HtmlToWml
                             .FirstOrDefault();
                         if (tdToAddAfter == null)
                         {
-                            tdToAddAfter = rowsToAddTo.Elements(XhtmlNoNamespace.td)
+                            tdToAddAfter = rowToAddTo.Elements(XhtmlNoNamespace.td)
                                 .LastOrDefault();
                         }
                         var td = new XElement(XhtmlNoNamespace.td,

--- a/TestFiles/T1880.html
+++ b/TestFiles/T1880.html
@@ -1,0 +1,399 @@
+<html><body><div class="div-margin-bottom"><h1>Testing Nested Rowspan	</h1><h2 class=".no-bottom-margin">Table with nested rowspan</h2><p class="div-margin-bottom forms-table">
+<table style="border-collapse: collapse; border: none;" width="690">
+<thead>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" colspan="5" width="690">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; background: #1F497D; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="background: #1F497D; padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="background: #1F497D; padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="background: #1F497D; padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="background: #1F497D; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="2" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="2" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="2" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="2" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="7" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="2" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="3" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="3" width="112">
+<p>test</p>
+<p>test</p>
+<p>test</p>
+<p>test</p>
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="3" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="3" width="112">
+<p>test</p>
+<p>test</p>
+<p>test</p>
+<p>test</p>
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; background: white; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" rowspan="3" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; background: white; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; background: white; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+<tr>
+<td style="border: solid windowtext 1.0pt; padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="93">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="295">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="78">
+<p>test</p>
+</td>
+<td style="padding: 0cm 1.4pt 0cm 1.4pt;" width="112">
+<p>test</p>
+</td>
+</tr>
+</thead>
+</table>
+</p>
+</div></body></html>


### PR DESCRIPTION
Added fix to conversion of html to wml for an error when there is a nested rowspan, this problem only occurs where the nested rowspan is in an earlier column. 