### PR TITLE
feat: improved memory consumption for PresentationBuilder.PublishSlides

### DIFF
--- a/OpenXmlPowerTools/PowerPoint/FluentPresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/FluentPresentationBuilder.cs
@@ -301,6 +301,9 @@ namespace Clippit.PowerPoint
                 var newSlide = _newDocument.PresentationPart.AddNewPart<SlidePart>();
                 var slideDocument = slide.GetXDocument();
                 
+                // cached annotation should be removed because it will be used in a new slide
+                slide.RemoveAnnotations<XDocument>();
+
                 // If we extract one slide, this slide should be visible
                 slideDocument.Root?.Attribute(NoNamespace.show)?.Remove();
 

--- a/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
@@ -85,16 +85,17 @@ namespace Clippit.PowerPoint
 
         public static IEnumerable<PmlDocument> PublishSlides(PresentationDocument srcDoc, string fileName)
         {
-            var slideList = srcDoc.PresentationPart.GetXDocument().Root.Descendants(P.sldId).ToList();
-            for (var slideNumber = 0; slideNumber < slideList.Count; slideNumber++)
+            var slidesCount = srcDoc.PresentationPart.GetXDocument().Root.Descendants(P.sldId).Count();
+            for (var slideNumber = 0; slideNumber < slidesCount; slideNumber++)
             {
                 using var streamDoc = OpenXmlMemoryStreamDocument.CreatePresentationDocument();
-                using (var output = streamDoc.GetPresentationDocument(new OpenSettings { AutoSave = false}))
+                using (var output = streamDoc.GetPresentationDocument(new OpenSettings { AutoSave = false }))
                 {
                     ExtractSlide(srcDoc, slideNumber, output);
 
-                    var slidePartId = slideList.ElementAt(slideNumber).Attribute(R.id)?.Value;
-                    var slidePart = (SlidePart)srcDoc.PresentationPart.GetPartById(slidePartId);
+                    var slides = output.PresentationPart.GetXDocument().Root.Descendants(P.sldId);
+                    var slidePartId = slides.ElementAt(0).Attribute(R.id)?.Value;
+                    var slidePart = (SlidePart)output.PresentationPart.GetPartById(slidePartId);
                     output.PackageProperties.Title = PresentationBuilderTools.GetSlideTitle(slidePart);
                 }
 


### PR DESCRIPTION
The improvement consists of two parts:
1) Slide's title is retrieved from the generated slide rather than from the original one. There is no need to load and parse the content for the slide twice (once for the original slide and once for the new one during generation)
2) The source XDoc for generating a slide is retrieved using `slide.GetXDocument()`, then it saves the `XDocument` in the `.Annotation<XDocument>()`. So, there is a direct reference from the original slide to the new one. That's why the generated slides are not collected by GC (they were collected after the original PresentationDocument disposal).

You can see the difference in memory results below (execution is paused before `srcDoc` disposal).

Code:
```cs
[Fact]
public void MemoryTest()
{
    var sourcePath = @"TESTFILE.pptx";
    var openSettings = new OpenSettings { AutoSave = false };

    using (var srcStream = File.Open(sourcePath, FileMode.Open))
    using (var srcDoc = OpenXmlExtensions.OpenPresentation(srcStream, false, openSettings))
    {
        var index = 1;
        foreach (var slide in PresentationBuilder.PublishSlides(srcDoc, sourcePath))
        {
            index++;
        }
    }
}
```

Before:
![devenv_m3dFruyAZF](https://user-images.githubusercontent.com/1970236/146380925-884a6373-c39d-4473-8e7d-6073bb1d50af.png)

After:
![devenv_0nBlFZiHFo](https://user-images.githubusercontent.com/1970236/146380954-47abdaef-952f-477f-825a-20a0c3f13a2f.png)
