### PR TITLE
feat: PublishSlides: reduced memory consumption

### DIFF
--- a/OpenXmlPowerTools/PowerPoint/FluentPresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/FluentPresentationBuilder.cs
@@ -18,8 +18,7 @@ namespace Clippit.PowerPoint
         private SlideSize _slideSize;
         private bool _isDocumentInitialized;
         
-        private readonly List<ImageData> _images = new();
-        private readonly List<MediaData> _mediaList = new();
+        private readonly List<ContentData> _mediaCache = new();
         private readonly List<SlideMasterData> _slideMasterList = new();
 
         internal FluentPresentationBuilder(PresentationDocument presentationDocument)
@@ -887,7 +886,8 @@ namespace Clippit.PowerPoint
                     var id = newContentPart.GetIdOfPart(newPart);
                     temp.AddContentPartRelTypeResourceIdTupple(newContentPart, newPart.RelationshipType, id);
 
-                    temp.WriteImage(newPart);
+                    using (var stream = oldPart.GetStream())
+                        newPart.FeedData(stream);
                     imageReference.SetAttributeValue(attributeName, id);
                 }
                 else
@@ -1070,27 +1070,25 @@ namespace Clippit.PowerPoint
         // General function for handling images that tries to use an existing image if they are the same
         private ImageData ManageImageCopy(ImagePart oldImage)
         {
-            var oldImageData = new ImageData(oldImage);
-            foreach (var item in _images)
-            {
-                if (item.Compare(oldImageData))
-                    return item;
-            }
-            _images.Add(oldImageData);
-            return oldImageData;
+            return GetOrAddCachedMedia(new ImageData(oldImage));
         }
 
         // General function for handling media that tries to use an existing media item if they are the same
         private MediaData ManageMediaCopy(DataPart oldMedia)
         {
-            var oldMediaData = new MediaData(oldMedia);
-            foreach (var item in _mediaList)
+            return GetOrAddCachedMedia(new MediaData(oldMedia));
+        }
+        
+        private T GetOrAddCachedMedia<T>(T contentData) where T : ContentData
+        {
+            var duplicateItem = _mediaCache.FirstOrDefault(x => x.Compare(contentData));
+            if (duplicateItem != null)
             {
-                if (item.Compare(oldMediaData))
-                    return item;
+                return (T)duplicateItem;
             }
-            _mediaList.Add(oldMediaData);
-            return oldMediaData;
+
+            _mediaCache.Add(contentData);
+            return contentData;
         }
 
         private ThemePart CopyThemePart(SlideMasterPart slideMasterPart, ThemePart oldThemePart, double scaleFactor)

--- a/OpenXmlPowerTools/Word/DocumentBuilder.cs
+++ b/OpenXmlPowerTools/Word/DocumentBuilder.cs
@@ -3208,7 +3208,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                     var id = newContentPart.GetIdOfPart(newPart);
                     temp.AddContentPartRelTypeResourceIdTupple(newContentPart, newPart.RelationshipType, id);
                     imageReference.SetAttributeValue(attributeName, id);
-                    temp.WriteImage(newPart);
+                    using (var stream = oldPart.GetStream())
+                        newPart.FeedData(stream);
                 }
                 else
                 {


### PR DESCRIPTION
This PR addresses memory consumption on pptx PublishSlides.

PptxContent copy routine uses media duplicate checking. Images/media were loaded in memory all the time (as a cache, the content was copied to a byte array) and all media were compared against each other on cache lookup (byte by byte comparison). Now, SHA256 hash is computed on media content and stored in memory (256 bits per media data), so cache lookup is based on content type + hash. This optimization removes media byte content from memory and improves cache lookup speed (but needs to compute a cache).

This improvement also affects all operations where CopyMedia/Images are involved (not only PublishSlides).

Rough perf stats on my 1.8 GB pptx file (tested via dotMemory):

| Method                        | Allocated objs | Allocated bytes | PeakMemory    | Time             |
|-------------------------------|----------------|-----------------|---------------|------------------|
| PublishSlides_Original        | 4,911,955      | 21,079,000,567  | 4,120,592,384 | 00:01:16.5428780 |
| PublishSlides_Optimized       | 4,909,955      | 13,030,037,546  | 1,503,330,304 | 00:01:20.7666303 |

Peak memory is retrieved via `Process.GetCurrentProcess().PeakWorkingSet64`