### PR TITLE
fix: PtOpenXmlUtil: process corrupted OpenXmlPart items

### DIFF
--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -31,6 +31,11 @@ namespace Clippit
 
         public static byte[] ComputeHash(this Stream stream)
         {
+            // HACK: disable Crc32 validation on zip entries to support corrupted content
+            // SetLength disables validation on a ProgressiveCrcCalculatingStream (NetFramework)
+            // see https://github.com/sergey-tihon/Clippit/issues/55
+            if (stream.CanSeek) stream.SetLength(stream.Length);
+
             using var hashAlgo = System.Security.Cryptography.SHA256.Create();
             return hashAlgo.ComputeHash(stream);
         }


### PR DESCRIPTION
Fixes #55 

`FileFormatException` is thrown only on classic NetFramework.

The root cause of this exception is that OpenXmlPart's content is corrupted. That's why `ProgressiveCrcCalculatingStream` [throws exception](https://referencesource.microsoft.com/#windowsbase/Base/MS/Internal/IO/Zip/ProgressiveCrcCalculatingStream.cs,162) during Crc32 validation check.
As a hacky workaround `Stream.SetLength(...)` is used [to disable crc validation](https://referencesource.microsoft.com/#windowsbase/Base/MS/Internal/IO/Zip/ProgressiveCrcCalculatingStream.cs,113).

`CanSeek` is used to prevent bad situations and reduce unnecessary calls.
Opposite to that [RuntimeInformation.FrameworkDescription](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription) could be used to determine the NetFramework in runtime.