### PR TITLE
perf: improved PublishSlides perf

### DIFF
--- a/OpenXmlPowerTools/PowerPoint/FluentPresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/FluentPresentationBuilder.cs
@@ -329,20 +329,21 @@ namespace Clippit.PowerPoint
             while (count > 0 && start < slideList.Count)
             {
                 var slide = (SlidePart)sourceDocument.PresentationPart.GetPartById(slideList.ElementAt(start).Attribute(R.id).Value);
-
                 var newSlide = _newDocument.PresentationPart.AddNewPart<SlidePart>();
-                var slideDocument = slide.GetXDocument();
-                
-                // cached annotation should be removed because it will be used in a new slide
-                slide.RemoveAnnotations<XDocument>();
 
+                using (var sourceStream = slide.GetStream())
+                using (var targetStream = newSlide.GetStream(FileMode.Create, FileAccess.Write))
+                {
+                    sourceStream.CopyTo(targetStream);
+                }
+                
+                var slideDocument = newSlide.GetXDocument();
                 if (unHideSlides)
                 {
                     slideDocument.Root?.Attribute(NoNamespace.show)?.Remove();
                 }
-
+                
                 SlideLayoutData.ScaleShapes(slideDocument, scaleFactor);
-                newSlide.PutXDocument(slideDocument);
                 
                 PBT.AddRelationships(slide, newSlide, new[] { newSlide.GetXDocument().Root });
                 CopyRelatedPartsForContentParts(slide, newSlide, new[] { newSlide.GetXDocument().Root });

--- a/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PowerPoint/PresentationBuilder.cs
@@ -87,7 +87,7 @@ namespace Clippit.PowerPoint
 
         public static IEnumerable<PmlDocument> PublishSlides(PresentationDocument srcDoc, string fileName)
         {
-            var slidesCount = srcDoc.PresentationPart.GetXDocument().Root.Descendants(P.sldId).Count();
+            var slidesCount = srcDoc.PresentationPart.GetXElement().Descendants(P.sldId).Count();
             for (var slideNumber = 0; slideNumber < slidesCount; slideNumber++)
             {
                 using var streamDoc = OpenXmlMemoryStreamDocument.CreatePresentationDocument();
@@ -95,10 +95,12 @@ namespace Clippit.PowerPoint
                 {
                     ExtractSlide(srcDoc, slideNumber, output);
 
-                    var slides = output.PresentationPart.GetXDocument().Root.Descendants(P.sldId);
-                    var slidePartId = slides.ElementAt(0).Attribute(R.id)?.Value;
+                    var slides = output.PresentationPart.GetXElement().Descendants(P.sldId);
+                    var slidePartId = slides.Single().Attribute(R.id)?.Value;
                     var slidePart = (SlidePart)output.PresentationPart.GetPartById(slidePartId);
-                    output.PackageProperties.Title = PresentationBuilderTools.GetSlideTitle(slidePart);
+                    var title = PresentationBuilderTools.GetSlideTitle(slidePart.GetXElement());
+
+                    output.PackageProperties.Title = title;
                 }
 
                 var slideDoc = streamDoc.GetModifiedPmlDocument();


### PR DESCRIPTION
After conducting some research, I have found that it is possible to further improve the performance of PublishSlides.

The following numbers are specific to the net6 branch. While I have not tested this code on the main branch, I believe it should work similarly (but should be tested anyway).

## Part 0. Initial perf values

I've tried to run PublishSlides method on one of my local pptx files (with many svg items inside).

Initial values are:
- Total time: 130s
- GC Time: 43.869s
- Peak memory: 480 MB
- Allocated: ~7.05 GB
![image](https://user-images.githubusercontent.com/1970236/227967369-54bb6f30-030b-4e82-bc1d-f37e24330352.png)

## Part 1. FluentPresentationBuilder

I've changed these lines:
```cs
var slideDocument = slide.GetXDocument();
slide.RemoveAnnotations<XDocument>();
...
newSlide.PutXDocument(slideDocument);
```

to these
```cs
using (var sourceStream = slide.GetStream())
using (var targetStream = newSlide.GetStream(FileMode.Create, FileAccess.Write))
{
    sourceStream.CopyTo(targetStream);
}
var slideDocument = newSlide.GetXDocument();
```

There is no need to call `PutXDocument` method because we can directly pipe the source stream to the target stream (without unnecessary XmlWriter serializer work on PutXDocument side).

New results after these changes:
- Total time: 112s
- GC Time: 38.329s
- Peak memory: 365 MB
- Allocated: ~6.74 GB
![image](https://user-images.githubusercontent.com/1970236/227967923-6cb2968d-ba4f-4a1a-bd78-d8f98fb51801.png)

## Part 2. GetSlideTitle
`AppendSlides` method uses `XDocument` generated from the new slide everywhere, but `GetSlideTitle` uses only OpenXML methods. As a result, the slide is read/deserialized multiple times (one time for XDocument, and another for OpenXML).

The solution was to use the same XDocument-based approach for title extraction, because XDocument is stored (cached) in SlidePart as a feature and there is no need to do anything addtional from IO/CPU side.

New results after this change:
- Total time: 48s
- GC Time: 8.775s
- Peak memory: 242 MB
- Allocated: ~3.74 GB
![image](https://user-images.githubusercontent.com/1970236/227969774-68f5a3d2-a50f-447a-b7da-d7ef2d78c408.png)
