### PR TITLE
Document Assembler - Small Code Reorganisation

### DIFF
--- a/Clippit/Word/Assembler/ErrorHandler.cs
+++ b/Clippit/Word/Assembler/ErrorHandler.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Clippit.Word.Assembler
+{
+    internal static class ErrorHandler
+    {
+        internal static object CreateContextErrorMessage(this XElement element, string errorMessage, TemplateError templateError)
+        {
+            XElement para = element.Descendants(W.p).FirstOrDefault();
+            XElement run = element.Descendants(W.r).FirstOrDefault();
+            var errorRun = CreateRunErrorMessage(errorMessage, templateError);
+            if (para != null)
+                return new XElement(W.p, errorRun);
+            else
+                return errorRun;
+        }
+
+        internal static XElement CreateRunErrorMessage(string errorMessage, TemplateError templateError)
+        {
+            templateError.HasError = true;
+            var errorRun = new XElement(W.r,
+                new XElement(W.rPr,
+                    new XElement(W.color, new XAttribute(W.val, "FF0000")),
+                    new XElement(W.highlight, new XAttribute(W.val, "yellow"))),
+                    new XElement(W.t, errorMessage));
+            return errorRun;
+        }
+
+        internal static XElement CreateParaErrorMessage(string errorMessage, TemplateError templateError)
+        {
+            templateError.HasError = true;
+            var errorPara = new XElement(W.p,
+                new XElement(W.r,
+                    new XElement(W.rPr,
+                        new XElement(W.color, new XAttribute(W.val, "FF0000")),
+                        new XElement(W.highlight, new XAttribute(W.val, "yellow"))),
+                        new XElement(W.t, errorMessage)));
+            return errorPara;
+        }
+    }
+}

--- a/Clippit/Word/Assembler/ErrorHandler.cs
+++ b/Clippit/Word/Assembler/ErrorHandler.cs
@@ -9,7 +9,11 @@ namespace Clippit.Word.Assembler
 {
     internal static class ErrorHandler
     {
-        internal static object CreateContextErrorMessage(this XElement element, string errorMessage, TemplateError templateError)
+        internal static object CreateContextErrorMessage(
+            this XElement element,
+            string errorMessage,
+            TemplateError templateError
+        )
         {
             XElement para = element.Descendants(W.p).FirstOrDefault();
             XElement run = element.Descendants(W.r).FirstOrDefault();
@@ -23,23 +27,33 @@ namespace Clippit.Word.Assembler
         internal static XElement CreateRunErrorMessage(string errorMessage, TemplateError templateError)
         {
             templateError.HasError = true;
-            var errorRun = new XElement(W.r,
-                new XElement(W.rPr,
+            var errorRun = new XElement(
+                W.r,
+                new XElement(
+                    W.rPr,
                     new XElement(W.color, new XAttribute(W.val, "FF0000")),
-                    new XElement(W.highlight, new XAttribute(W.val, "yellow"))),
-                    new XElement(W.t, errorMessage));
+                    new XElement(W.highlight, new XAttribute(W.val, "yellow"))
+                ),
+                new XElement(W.t, errorMessage)
+            );
             return errorRun;
         }
 
         internal static XElement CreateParaErrorMessage(string errorMessage, TemplateError templateError)
         {
             templateError.HasError = true;
-            var errorPara = new XElement(W.p,
-                new XElement(W.r,
-                    new XElement(W.rPr,
+            var errorPara = new XElement(
+                W.p,
+                new XElement(
+                    W.r,
+                    new XElement(
+                        W.rPr,
                         new XElement(W.color, new XAttribute(W.val, "FF0000")),
-                        new XElement(W.highlight, new XAttribute(W.val, "yellow"))),
-                        new XElement(W.t, errorMessage)));
+                        new XElement(W.highlight, new XAttribute(W.val, "yellow"))
+                    ),
+                    new XElement(W.t, errorMessage)
+                )
+            );
             return errorPara;
         }
     }

--- a/Clippit/Word/Assembler/PA.cs
+++ b/Clippit/Word/Assembler/PA.cs
@@ -1,0 +1,27 @@
+﻿using System.Xml.Linq;
+
+namespace Clippit.Word.Assembler
+{
+    internal static class PA
+    {
+        public static XName Image = "Image";
+        public static XName Content = "Content";
+        public static XName DocumentTemplate = "DocumentTemplate";
+        public static XName Document = "Document";
+        public static XName Table = "Table";
+        public static XName Repeat = "Repeat";
+        public static XName EndRepeat = "EndRepeat";
+        public static XName Conditional = "Conditional";
+        public static XName EndConditional = "EndConditional";
+
+        public static XName Select = "Select";
+        public static XName Optional = "Optional";
+        public static XName Match = "Match";
+        public static XName NotMatch = "NotMatch";
+        public static XName Depth = "Depth";
+        public static XName Align = "Align";
+        public static XName Path = "Path";
+        public static XName Data = "Data";
+        public static XName PageBreakAfter = "PageBreakAfter";
+    }
+}

--- a/Clippit/Word/Assembler/PASchemaSet.cs
+++ b/Clippit/Word/Assembler/PASchemaSet.cs
@@ -1,0 +1,10 @@
+﻿using System.Xml.Schema;
+
+namespace Clippit.Word.Assembler
+{
+    internal class PASchemaSet
+    {
+        public string XsdMarkup;
+        public XmlSchemaSet SchemaSet;
+    }
+}

--- a/Clippit/Word/Assembler/TemplateError.cs
+++ b/Clippit/Word/Assembler/TemplateError.cs
@@ -1,0 +1,7 @@
+﻿namespace Clippit.Word.Assembler
+{
+    internal class TemplateError
+    {
+        internal bool HasError { get; set; }
+    }
+}

--- a/Clippit/Word/Assembler/XPathExtensions.cs
+++ b/Clippit/Word/Assembler/XPathExtensions.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace Clippit.Word.Assembler
+{
+    internal static class XPathExtensions
+    {
+        internal static string[] EvaluateXPath(this XElement element, string xPath, bool optional)
+        {
+            object xPathSelectResult;
+            try
+            {
+                // support some cells in the table may not have an xpath expression.
+                if (string.IsNullOrWhiteSpace(xPath))
+                {
+                    return [];
+                }
+
+                xPathSelectResult = element.XPathEvaluate(xPath);
+            }
+            catch (XPathException e)
+            {
+                throw new XPathException("XPathException: " + e.Message, e);
+            }
+
+            if (xPathSelectResult is IEnumerable enumerable and not string)
+            {
+                var result = enumerable
+                    .Cast<XObject>()
+                    .Select(x =>
+                        x switch
+                        {
+                            XElement xElement => xElement.Value,
+                            XAttribute attribute => attribute.Value,
+                            _ => throw new ArgumentException($"Unknown element type: {x.GetType().Name}"),
+                        }
+                    )
+                    .ToArray();
+
+                if (result.Length == 0 && !optional)
+                    throw new XPathException($"XPath expression ({xPath}) returned no results");
+                return result;
+            }
+
+            return new[] { xPathSelectResult.ToString() };
+        }
+
+        internal static string EvaluateXPathToString(this XElement element, string xPath, bool optional)
+        {
+            var selectedData = element.EvaluateXPath(xPath, true);
+
+            return selectedData.Length switch
+            {
+                0 when optional => string.Empty,
+                0 => throw new XPathException($"XPath expression ({xPath}) returned no results"),
+                > 1 => throw new XPathException($"XPath expression ({xPath}) returned more than one node"),
+                _ => selectedData.First(),
+            };
+        }
+    }
+}

--- a/Clippit/Word/DocumentAssembler.cs
+++ b/Clippit/Word/DocumentAssembler.cs
@@ -16,6 +16,8 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Path = System.IO.Path;
 
+using Clippit.Word.Assembler;
+
 namespace Clippit.Word
 {
     public static class DocumentAssembler
@@ -139,7 +141,7 @@ namespace Clippit.Word
                         var newPara = new XElement(element);
                         var newMeta = newPara.Elements().First(n => s_metaToForceToBlock.Contains(n.Name));
                         newMeta.ReplaceWith(
-                            CreateRunErrorMessage("Error: Unmatched metadata can't be in paragraph with other text", te)
+                            ErrorHandler.CreateRunErrorMessage("Error: Unmatched metadata can't be in paragraph with other text", te)
                         );
                         return newPara;
                     }
@@ -154,20 +156,12 @@ namespace Clippit.Word
                 if (count % 2 == 0)
                 {
                     if (childMeta.Count(c => c.Name == PA.Repeat) != childMeta.Count(c => c.Name == PA.EndRepeat))
-                        return CreateContextErrorMessage(
-                            element,
-                            "Error: Mismatch Repeat / EndRepeat at run level",
-                            te
-                        );
+                        return element.CreateContextErrorMessage("Error: Mismatch Repeat / EndRepeat at run level", te);
                     if (
                         childMeta.Count(c => c.Name == PA.Conditional)
                         != childMeta.Count(c => c.Name == PA.EndConditional)
                     )
-                        return CreateContextErrorMessage(
-                            element,
-                            "Error: Mismatch Conditional / EndConditional at run level",
-                            te
-                        );
+                        return element.CreateContextErrorMessage("Error: Mismatch Conditional / EndConditional at run level", te);
                     return new XElement(
                         element.Name,
                         element.Attributes(),
@@ -176,7 +170,7 @@ namespace Clippit.Word
                 }
                 else
                 {
-                    return CreateContextErrorMessage(element, "Error: Invalid metadata at run level", te);
+                    return element.CreateContextErrorMessage("Error: Invalid metadata at run level", te);
                 }
             }
             return new XElement(
@@ -190,16 +184,12 @@ namespace Clippit.Word
         {
             foreach (var element in xDocRoot.Descendants(PA.EndRepeat).ToList())
             {
-                var error = CreateContextErrorMessage(element, "Error: EndRepeat without matching Repeat", te);
+                var error = element.CreateContextErrorMessage("Error: EndRepeat without matching Repeat", te);
                 element.ReplaceWith(error);
             }
             foreach (var element in xDocRoot.Descendants(PA.EndConditional).ToList())
             {
-                var error = CreateContextErrorMessage(
-                    element,
-                    "Error: EndConditional without matching Conditional",
-                    te
-                );
+                var error = element.CreateContextErrorMessage("Error: EndConditional without matching Conditional", te);
                 element.ReplaceWith(error);
             }
         }
@@ -268,7 +258,7 @@ namespace Clippit.Word
                 if (followingElement == null || followingElement.Name != W.tbl)
                 {
                     table.ReplaceWith(
-                        CreateParaErrorMessage("Table metadata is not immediately followed by a table", te)
+                        ErrorHandler.CreateParaErrorMessage("Table metadata is not immediately followed by a table", te)
                     );
                     continue;
                 }
@@ -287,7 +277,7 @@ namespace Clippit.Word
                 if (followingElement == null)
                 {
                     image.ReplaceWith(
-                        CreateParaErrorMessage("Image metadata is not immediately followed by an image", te)
+                        ErrorHandler.CreateParaErrorMessage("Image metadata is not immediately followed by an image", te)
                     );
                     continue;
                 }
@@ -309,7 +299,7 @@ namespace Clippit.Word
                         if (picture == null)
                         {
                             image.ReplaceWith(
-                                CreateParaErrorMessage("Image metadata does not contain picture element", te)
+                                ErrorHandler.CreateParaErrorMessage("Image metadata does not contain picture element", te)
                             );
                             continue;
                         }
@@ -391,7 +381,7 @@ namespace Clippit.Word
                     if (matchingEnd == null)
                     {
                         metadata.ReplaceWith(
-                            CreateParaErrorMessage(
+                            ErrorHandler.CreateParaErrorMessage(
                                 $"{metadata.Name.LocalName} does not have matching {matchingEndName.LocalName}",
                                 te
                             )
@@ -449,11 +439,11 @@ namespace Clippit.Word
                         if (alias != null && xml.Name.LocalName != alias)
                         {
                             return element.Parent.Name == W.p
-                                ? CreateRunErrorMessage(
+                                ? ErrorHandler.CreateRunErrorMessage(
                                     "Error: Content control alias does not match metadata element name",
                                     te
                                 )
-                                : CreateParaErrorMessage(
+                                : ErrorHandler.CreateParaErrorMessage(
                                     "Error: Content control alias does not match metadata element name",
                                     te
                                 );
@@ -559,9 +549,9 @@ namespace Clippit.Word
                         if (runToReplace == null)
                             throw new OpenXmlPowerToolsException("Internal error");
                         if (rri.XmlExceptionMessage != null)
-                            runToReplace.ReplaceWith(CreateRunErrorMessage(rri.XmlExceptionMessage, te));
+                            runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.XmlExceptionMessage, te));
                         else if (rri.SchemaValidationMessage != null)
-                            runToReplace.ReplaceWith(CreateRunErrorMessage(rri.SchemaValidationMessage, te));
+                            runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.SchemaValidationMessage, te));
                         else
                         {
                             var newXml = new XElement(rri.Xml);
@@ -660,9 +650,9 @@ namespace Clippit.Word
                         if (runToReplace == null)
                             throw new OpenXmlPowerToolsException("Internal error");
                         if (rri.XmlExceptionMessage != null)
-                            runToReplace.ReplaceWith(CreateRunErrorMessage(rri.XmlExceptionMessage, te));
+                            runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.XmlExceptionMessage, te));
                         else if (rri.SchemaValidationMessage != null)
-                            runToReplace.ReplaceWith(CreateRunErrorMessage(rri.SchemaValidationMessage, te));
+                            runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.SchemaValidationMessage, te));
                         else
                         {
                             var newXml = new XElement(rri.Xml);
@@ -691,11 +681,11 @@ namespace Clippit.Word
             }
             catch (XmlException e)
             {
-                return CreateParaErrorMessage("XmlException: " + e.Message, te);
+                return ErrorHandler.CreateParaErrorMessage("XmlException: " + e.Message, te);
             }
             var schemaError = ValidatePerSchema(xml);
             if (schemaError is not null)
-                return CreateParaErrorMessage("Schema Validation Error: " + schemaError, te);
+                return ErrorHandler.CreateParaErrorMessage("Schema Validation Error: " + schemaError, te);
             return xml;
         }
 
@@ -836,36 +826,7 @@ namespace Clippit.Word
             return message;
         }
 
-        private static class PA
-        {
-            public static readonly XName Image = "Image";
-            public static readonly XName Content = "Content";
-            public static readonly XName Table = "Table";
-            public static readonly XName Repeat = "Repeat";
-            public static readonly XName EndRepeat = "EndRepeat";
-            public static readonly XName Conditional = "Conditional";
-            public static readonly XName EndConditional = "EndConditional";
-
-            public static readonly XName Select = "Select";
-            public static readonly XName Optional = "Optional";
-            public static readonly XName Match = "Match";
-            public static readonly XName NotMatch = "NotMatch";
-            public static readonly XName Depth = "Depth";
-            public static readonly XName Align = "Align";
-        }
-
-        private class PASchemaSet
-        {
-            public string XsdMarkup { get; set; }
-            public XmlSchemaSet SchemaSet { get; set; }
-        }
-
         private static Dictionary<XName, PASchemaSet> s_paSchemaSets;
-
-        private class TemplateError
-        {
-            public bool HasError { get; set; }
-        }
 
         /// <summary>
         /// Gets the next image relationship identifier of given part. The
@@ -1010,11 +971,7 @@ namespace Clippit.Word
             // check for first run having image element in it
             if (orig == null || !orig.Descendants(W.r).FirstOrDefault().Descendants(W.drawing).Any())
             {
-                return CreateContextErrorMessage(
-                    element,
-                    "Image metadata is not immediately followed by an image",
-                    templateError
-                );
+                return element.CreateContextErrorMessage("Image metadata is not immediately followed by an image", templateError);
             }
 
             // clone the paragraph, so repeating elements won't be overridden
@@ -1023,7 +980,7 @@ namespace Clippit.Word
             // get the xpath of of the element
             var xPath = (string)element.Attribute(PA.Select);
             // get image path
-            var imagePath = EvaluateXPathToString(data, xPath, false);
+            var imagePath = data.EvaluateXPathToString(xPath, false);
 
             // assign unique image and paragraph ids. Image id is document property Id  (wp:docPr)
             // and relationship id is rId. Their numbering is different.
@@ -1033,7 +990,7 @@ namespace Clippit.Word
             var inline = para.Descendants(W.drawing).Descendants(WP.inline).FirstOrDefault();
             if (inline == null)
             {
-                return CreateContextErrorMessage(element, "Image: invalid picture control", templateError);
+                return element.CreateContextErrorMessage("Image: invalid picture control", templateError);
             }
 
             // get aspect ratio option
@@ -1069,22 +1026,14 @@ namespace Clippit.Word
 
             if (extent == null || pictureExtent == null)
             {
-                return CreateContextErrorMessage(
-                    element,
-                    "Image: missing element in picture control - extent(s)",
-                    templateError
-                );
+                return element.CreateContextErrorMessage("Image: missing element in picture control - extent(s)", templateError);
             }
 
             // get docPr
             var docPr = inline.Descendants(WP.docPr).FirstOrDefault();
             if (docPr == null)
             {
-                return CreateContextErrorMessage(
-                    element,
-                    "Image: missing element in picture control - docPtr",
-                    templateError
-                );
+                return element.CreateContextErrorMessage("Image: missing element in picture control - docPtr", templateError);
             }
 
             docPr.SetAttributeValue(NoNamespace.id, imageId);
@@ -1109,7 +1058,7 @@ namespace Clippit.Word
                     if (ip is null)
                     {
                         error = "Failed to get image part";
-                        return CreateContextErrorMessage(element, string.Concat("Image: ", error), templateError);
+                        return element.CreateContextErrorMessage(string.Concat("Image: ", error), templateError);
                     }
 
                     ip.FeedData(stream);
@@ -1129,7 +1078,7 @@ namespace Clippit.Word
                         var ratio = height / (width * 1.0);
                         if (!int.TryParse(extent.Attribute(NoNamespace.cx).Value, out width))
                         {
-                            return CreateContextErrorMessage(element, "Image: Invalid image attributes", templateError);
+                            return element.CreateContextErrorMessage("Image: Invalid image attributes", templateError);
                         }
 
                         height = (int)(width * ratio);
@@ -1154,7 +1103,7 @@ namespace Clippit.Word
                 }
                 else
                 {
-                    return CreateContextErrorMessage(element, string.Concat("Image: ", error), templateError);
+                    return element.CreateContextErrorMessage(string.Concat("Image: ", error), templateError);
                 }
             }
 
@@ -1256,11 +1205,11 @@ namespace Clippit.Word
             string[] newValues;
             try
             {
-                newValues = EvaluateXPath(data, xPath, optional);
+                newValues = data.EvaluateXPath(xPath, optional);
             }
             catch (XPathException e)
             {
-                return CreateContextErrorMessage(element, "XPathException: " + e.Message, templateError);
+                return element.CreateContextErrorMessage("XPathException: " + e.Message, templateError);
             }
 
             var para = element.Descendants(A.r).FirstOrDefault();
@@ -1345,11 +1294,11 @@ namespace Clippit.Word
                 string[] newValues;
                 try
                 {
-                    newValues = EvaluateXPath(data, xPath, optional);
+                    newValues = data.EvaluateXPath(xPath, optional);
                 }
                 catch (XPathException e)
                 {
-                    return CreateContextErrorMessage(element, "XPathException: " + e.Message, templateError);
+                    return element.CreateContextErrorMessage("XPathException: " + e.Message, templateError);
                 }
 
                 var lines = newValues.SelectMany(x => x.Split('\n'));
@@ -1402,7 +1351,7 @@ namespace Clippit.Word
                 }
                 catch (XPathException e)
                 {
-                    return CreateContextErrorMessage(element, "XPathException: " + e.Message, templateError);
+                    return element.CreateContextErrorMessage("XPathException: " + e.Message, templateError);
                 }
                 if (!repeatingData.Any())
                 {
@@ -1415,7 +1364,7 @@ namespace Clippit.Word
                         //else
                         //    return new XElement(W.r);
                     }
-                    return CreateContextErrorMessage(element, "Repeat: Select returned no data", templateError);
+                    return element.CreateContextErrorMessage("Repeat: Select returned no data", templateError);
                 }
                 var newContent = repeatingData
                     .Select(d =>
@@ -1446,7 +1395,7 @@ namespace Clippit.Word
                     case "vertical":
                         return newContent;
                     default:
-                        return CreateContextErrorMessage(element, "Repeat: Invalid Align option", templateError);
+                        return element.CreateContextErrorMessage("Repeat: Invalid Align option", templateError);
                 }
             }
             if (element.Name == PA.Table)
@@ -1458,10 +1407,10 @@ namespace Clippit.Word
                 }
                 catch (XPathException e)
                 {
-                    return CreateContextErrorMessage(element, "XPathException: " + e.Message, templateError);
+                    return element.CreateContextErrorMessage("XPathException: " + e.Message, templateError);
                 }
                 if (!tableData.Any())
-                    return CreateContextErrorMessage(element, "Table Select returned no data", templateError);
+                    return element.CreateContextErrorMessage("Table Select returned no data", templateError);
                 var table = element.Element(W.tbl);
                 var protoRow = table.Elements(W.tr).Skip(1).FirstOrDefault();
                 var footerRowsBeforeTransform = table.Elements(W.tr).Skip(2).ToList();
@@ -1469,7 +1418,7 @@ namespace Clippit.Word
                     .Select(x => ContentReplacementTransform(x, data, templateError, part))
                     .ToList();
                 if (protoRow == null)
-                    return CreateContextErrorMessage(element, "Table does not contain a prototype row", templateError);
+                    return element.CreateContextErrorMessage("Table does not contain a prototype row", templateError);
                 protoRow.Descendants(W.bookmarkStart).Remove();
                 protoRow.Descendants(W.bookmarkEnd).Remove();
                 var newTable = new XElement(
@@ -1503,7 +1452,7 @@ namespace Clippit.Word
                                 string[] newValues;
                                 try
                                 {
-                                    newValues = EvaluateXPath(d, xPath, false);
+                                    newValues = d.EvaluateXPath(xPath, false);
                                 }
                                 catch (XPathException e)
                                 {
@@ -1513,7 +1462,7 @@ namespace Clippit.Word
                                         new XElement(
                                             W.p,
                                             paragraph.Element(W.pPr),
-                                            CreateRunErrorMessage(e.Message, templateError)
+                                            ErrorHandler.CreateRunErrorMessage(e.Message, templateError)
                                         )
                                     );
                                     return errorCell;
@@ -1544,26 +1493,18 @@ namespace Clippit.Word
                 var notMatch = (string)element.Attribute(PA.NotMatch);
 
                 if (match == null && notMatch == null)
-                    return CreateContextErrorMessage(
-                        element,
-                        "Conditional: Must specify either Match or NotMatch",
-                        templateError
-                    );
+                    return element.CreateContextErrorMessage("Conditional: Must specify either Match or NotMatch", templateError);
                 if (match != null && notMatch != null)
-                    return CreateContextErrorMessage(
-                        element,
-                        "Conditional: Cannot specify both Match and NotMatch",
-                        templateError
-                    );
+                    return element.CreateContextErrorMessage("Conditional: Cannot specify both Match and NotMatch", templateError);
 
                 string testValue;
                 try
                 {
-                    testValue = EvaluateXPathToString(data, xPath, false);
+                    testValue = data.EvaluateXPathToString(xPath, false);
                 }
                 catch (XPathException e)
                 {
-                    return CreateContextErrorMessage(element, e.Message, templateError);
+                    return element.CreateContextErrorMessage(e.Message, templateError);
                 }
 
                 if ((match != null && testValue == match) || (notMatch != null && testValue != notMatch))
@@ -1582,100 +1523,6 @@ namespace Clippit.Word
             );
         }
 
-        private static object CreateContextErrorMessage(
-            XElement element,
-            string errorMessage,
-            TemplateError templateError
-        )
-        {
-            var para = element.Descendants(W.p).FirstOrDefault();
-            //var run = element.Descendants(W.r).FirstOrDefault();
-            var errorRun = CreateRunErrorMessage(errorMessage, templateError);
-            return para != null ? new XElement(W.p, errorRun) : errorRun;
-        }
-
-        private static XElement CreateRunErrorMessage(string errorMessage, TemplateError templateError)
-        {
-            templateError.HasError = true;
-            var errorRun = new XElement(
-                W.r,
-                new XElement(
-                    W.rPr,
-                    new XElement(W.color, new XAttribute(W.val, "FF0000")),
-                    new XElement(W.highlight, new XAttribute(W.val, "yellow"))
-                ),
-                new XElement(W.t, errorMessage)
-            );
-            return errorRun;
-        }
-
-        private static XElement CreateParaErrorMessage(string errorMessage, TemplateError templateError)
-        {
-            templateError.HasError = true;
-            var errorPara = new XElement(
-                W.p,
-                new XElement(
-                    W.r,
-                    new XElement(
-                        W.rPr,
-                        new XElement(W.color, new XAttribute(W.val, "FF0000")),
-                        new XElement(W.highlight, new XAttribute(W.val, "yellow"))
-                    ),
-                    new XElement(W.t, errorMessage)
-                )
-            );
-            return errorPara;
-        }
-
-        private static string[] EvaluateXPath(XElement element, string xPath, bool optional)
-        {
-            //support some cells in the table may not have an xpath expression.
-            if (string.IsNullOrWhiteSpace(xPath))
-                return Array.Empty<string>();
-
-            object xPathSelectResult;
-            try
-            {
-                xPathSelectResult = element.XPathEvaluate(xPath);
-            }
-            catch (XPathException e)
-            {
-                throw new XPathException("XPathException: " + e.Message, e);
-            }
-
-            if (xPathSelectResult is IEnumerable enumerable and not string)
-            {
-                var result = enumerable
-                    .Cast<XObject>()
-                    .Select(x =>
-                        x switch
-                        {
-                            XElement xElement => xElement.Value,
-                            XAttribute attribute => attribute.Value,
-                            _ => throw new ArgumentException($"Unknown element type: {x.GetType().Name}"),
-                        }
-                    )
-                    .ToArray();
-
-                if (result.Length == 0 && !optional)
-                    throw new XPathException($"XPath expression ({xPath}) returned no results");
-                return result;
-            }
-
-            return new[] { xPathSelectResult.ToString() };
-        }
-
-        private static string EvaluateXPathToString(XElement element, string xPath, bool optional)
-        {
-            var selectedData = EvaluateXPath(element, xPath, true);
-
-            return selectedData.Length switch
-            {
-                0 when optional => string.Empty,
-                0 => throw new XPathException($"XPath expression ({xPath}) returned no results"),
-                > 1 => throw new XPathException($"XPath expression ({xPath}) returned more than one node"),
-                _ => selectedData.First(),
-            };
-        }
+        
     }
 }

--- a/Clippit/Word/DocumentAssembler.cs
+++ b/Clippit/Word/DocumentAssembler.cs
@@ -11,12 +11,11 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.XPath;
+using Clippit.Word.Assembler;
 using DocumentFormat.OpenXml.Packaging;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using Path = System.IO.Path;
-
-using Clippit.Word.Assembler;
 
 namespace Clippit.Word
 {
@@ -141,7 +140,10 @@ namespace Clippit.Word
                         var newPara = new XElement(element);
                         var newMeta = newPara.Elements().First(n => s_metaToForceToBlock.Contains(n.Name));
                         newMeta.ReplaceWith(
-                            ErrorHandler.CreateRunErrorMessage("Error: Unmatched metadata can't be in paragraph with other text", te)
+                            ErrorHandler.CreateRunErrorMessage(
+                                "Error: Unmatched metadata can't be in paragraph with other text",
+                                te
+                            )
                         );
                         return newPara;
                     }
@@ -161,7 +163,10 @@ namespace Clippit.Word
                         childMeta.Count(c => c.Name == PA.Conditional)
                         != childMeta.Count(c => c.Name == PA.EndConditional)
                     )
-                        return element.CreateContextErrorMessage("Error: Mismatch Conditional / EndConditional at run level", te);
+                        return element.CreateContextErrorMessage(
+                            "Error: Mismatch Conditional / EndConditional at run level",
+                            te
+                        );
                     return new XElement(
                         element.Name,
                         element.Attributes(),
@@ -277,7 +282,10 @@ namespace Clippit.Word
                 if (followingElement == null)
                 {
                     image.ReplaceWith(
-                        ErrorHandler.CreateParaErrorMessage("Image metadata is not immediately followed by an image", te)
+                        ErrorHandler.CreateParaErrorMessage(
+                            "Image metadata is not immediately followed by an image",
+                            te
+                        )
                     );
                     continue;
                 }
@@ -299,7 +307,10 @@ namespace Clippit.Word
                         if (picture == null)
                         {
                             image.ReplaceWith(
-                                ErrorHandler.CreateParaErrorMessage("Image metadata does not contain picture element", te)
+                                ErrorHandler.CreateParaErrorMessage(
+                                    "Image metadata does not contain picture element",
+                                    te
+                                )
                             );
                             continue;
                         }
@@ -551,7 +562,9 @@ namespace Clippit.Word
                         if (rri.XmlExceptionMessage != null)
                             runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.XmlExceptionMessage, te));
                         else if (rri.SchemaValidationMessage != null)
-                            runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.SchemaValidationMessage, te));
+                            runToReplace.ReplaceWith(
+                                ErrorHandler.CreateRunErrorMessage(rri.SchemaValidationMessage, te)
+                            );
                         else
                         {
                             var newXml = new XElement(rri.Xml);
@@ -652,7 +665,9 @@ namespace Clippit.Word
                         if (rri.XmlExceptionMessage != null)
                             runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.XmlExceptionMessage, te));
                         else if (rri.SchemaValidationMessage != null)
-                            runToReplace.ReplaceWith(ErrorHandler.CreateRunErrorMessage(rri.SchemaValidationMessage, te));
+                            runToReplace.ReplaceWith(
+                                ErrorHandler.CreateRunErrorMessage(rri.SchemaValidationMessage, te)
+                            );
                         else
                         {
                             var newXml = new XElement(rri.Xml);
@@ -971,7 +986,10 @@ namespace Clippit.Word
             // check for first run having image element in it
             if (orig == null || !orig.Descendants(W.r).FirstOrDefault().Descendants(W.drawing).Any())
             {
-                return element.CreateContextErrorMessage("Image metadata is not immediately followed by an image", templateError);
+                return element.CreateContextErrorMessage(
+                    "Image metadata is not immediately followed by an image",
+                    templateError
+                );
             }
 
             // clone the paragraph, so repeating elements won't be overridden
@@ -1026,14 +1044,20 @@ namespace Clippit.Word
 
             if (extent == null || pictureExtent == null)
             {
-                return element.CreateContextErrorMessage("Image: missing element in picture control - extent(s)", templateError);
+                return element.CreateContextErrorMessage(
+                    "Image: missing element in picture control - extent(s)",
+                    templateError
+                );
             }
 
             // get docPr
             var docPr = inline.Descendants(WP.docPr).FirstOrDefault();
             if (docPr == null)
             {
-                return element.CreateContextErrorMessage("Image: missing element in picture control - docPtr", templateError);
+                return element.CreateContextErrorMessage(
+                    "Image: missing element in picture control - docPtr",
+                    templateError
+                );
             }
 
             docPr.SetAttributeValue(NoNamespace.id, imageId);
@@ -1493,9 +1517,15 @@ namespace Clippit.Word
                 var notMatch = (string)element.Attribute(PA.NotMatch);
 
                 if (match == null && notMatch == null)
-                    return element.CreateContextErrorMessage("Conditional: Must specify either Match or NotMatch", templateError);
+                    return element.CreateContextErrorMessage(
+                        "Conditional: Must specify either Match or NotMatch",
+                        templateError
+                    );
                 if (match != null && notMatch != null)
-                    return element.CreateContextErrorMessage("Conditional: Cannot specify both Match and NotMatch", templateError);
+                    return element.CreateContextErrorMessage(
+                        "Conditional: Cannot specify both Match and NotMatch",
+                        templateError
+                    );
 
                 string testValue;
                 try
@@ -1522,7 +1552,5 @@ namespace Clippit.Word
                 element.Nodes().Select(n => ContentReplacementTransform(n, data, templateError, part))
             );
         }
-
-        
     }
 }


### PR DESCRIPTION
Hello Sergey,

Thanks for providing Clippit, though I am not using it yet, it's great that those of us relying on OpenXmlPowerTools have a maintained repository again!

I have some improvements that I want to make to DocumentAssembler these are:

1. Ability to create component templates for reusable parts of a template
2. Ability to use basic HTML formatting in DocumentAssembler (bold, italic, underline, hyperlink)

Before I get to these in my existing fork I have tried to move as much code as possible out of DocumentAssembler.cs, in the spirit of keeping PRs small I have done something similar in this PR.  The changes include:

1. Moving Definition classes PA and PASchemaset out to Assembler namespace
2. Moving TemplateError class out to Assembler namespace
3. Moving Error Message methods to the ErrorHandler class
4. Creating Extensions methods for the XPath wrappers methods

This is by no means a large scale refactor, but I wanted to start somewhere as the original Open XML Power Tools code is a bit hairy.

Once this PR is merged then I will again do separate PRs for the above functionality.  

All tests are passing (other than the one test that has been explicitly marked to skip).  

Hope this works for you?
