### PR TITLE
feat: handle invalid xml characters

### DIFF
--- a/Clippit.Tests/Excel/Samples/SpreadsheetWriterSamples.cs
+++ b/Clippit.Tests/Excel/Samples/SpreadsheetWriterSamples.cs
@@ -1,29 +1,24 @@
-﻿using System;
-using System.IO;
-using Clippit.Excel;
+﻿using Clippit.Excel;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Clippit.Tests.Excel.Samples
 {
-    public class SpreadsheetWriterSamples : TestsBase
+    public class SpreadsheetWriterSamples(ITestOutputHelper log) : TestsBase(log)
     {
-        public SpreadsheetWriterSamples(ITestOutputHelper log)
-            : base(log) { }
-
         [Fact]
         public void Sample1()
         {
             var wb = new WorkbookDfn
             {
-                Worksheets = new[]
-                {
+                Worksheets =
+                [
                     new WorksheetDfn
                     {
                         Name = "MyFirstSheet",
                         TableName = "NamesAndRates",
-                        ColumnHeadings = new[]
-                        {
+                        ColumnHeadings =
+                        [
                             new CellDfn { Value = "Name", Bold = true },
                             new CellDfn
                             {
@@ -37,13 +32,13 @@ namespace Clippit.Tests.Excel.Samples
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Left,
                             },
-                        },
-                        Rows = new[]
-                        {
+                        ],
+                        Rows =
+                        [
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "Eric" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = 50 },
                                     new CellDfn
@@ -52,12 +47,12 @@ namespace Clippit.Tests.Excel.Samples
                                         Value = (decimal)45.00,
                                         FormatCode = "0.00",
                                     },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "Bob" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = 42 },
                                     new CellDfn
@@ -66,11 +61,11 @@ namespace Clippit.Tests.Excel.Samples
                                         Value = (decimal)78.00,
                                         FormatCode = "0.00",
                                     },
-                                },
+                                ],
                             },
-                        },
+                        ],
                     },
-                },
+                ],
             };
 
             var fileName = Path.Combine(TempDir, "Sw_Example1.xlsx");
@@ -83,13 +78,13 @@ namespace Clippit.Tests.Excel.Samples
         {
             var wb = new WorkbookDfn
             {
-                Worksheets = new[]
-                {
+                Worksheets =
+                [
                     new WorksheetDfn
                     {
                         Name = "MyFirstSheet",
-                        ColumnHeadings = new[]
-                        {
+                        ColumnHeadings =
+                        [
                             new CellDfn { Value = "DataType", Bold = true },
                             new CellDfn
                             {
@@ -97,29 +92,29 @@ namespace Clippit.Tests.Excel.Samples
                                 Bold = true,
                                 HorizontalCellAlignment = HorizontalCellAlignment.Right,
                             },
-                        },
-                        Rows = new[]
-                        {
+                        ],
+                        Rows =
+                        [
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "Boolean" },
                                     new CellDfn { CellDataType = CellDataType.Boolean, Value = true },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "Boolean" },
                                     new CellDfn { CellDataType = CellDataType.Boolean, Value = false },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "String" },
                                     new CellDfn
                                     {
@@ -127,76 +122,76 @@ namespace Clippit.Tests.Excel.Samples
                                         Value = "A String",
                                         HorizontalCellAlignment = HorizontalCellAlignment.Right,
                                     },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "int" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = 100 },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "int?" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = (int?)100 },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "int? (is null)" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = null },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "uint" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = (uint)101 },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "long" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = long.MaxValue },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "float" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = (float)123.45 },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "double" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = 123.45 },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn { CellDataType = CellDataType.String, Value = "decimal" },
                                     new CellDfn { CellDataType = CellDataType.Number, Value = (decimal)123.45 },
-                                },
+                                ],
                             },
                             new RowDfn
                             {
-                                Cells = new[]
-                                {
+                                Cells =
+                                [
                                     new CellDfn
                                     {
                                         CellDataType = CellDataType.Date,
@@ -211,16 +206,87 @@ namespace Clippit.Tests.Excel.Samples
                                         Bold = true,
                                         HorizontalCellAlignment = HorizontalCellAlignment.Center,
                                     },
-                                },
+                                ],
                             },
-                        },
+                        ],
                     },
-                },
+                ],
             };
 
             var fileName = Path.Combine(TempDir, "Sw_Example2.xlsx");
             using var stream = File.Open(fileName, FileMode.OpenOrCreate);
             wb.WriteTo(stream);
+        }
+
+        [Fact]
+        public void CanEncodeInvalidXmlCharacters()
+        {
+            var wb = new WorkbookDfn
+            {
+                Worksheets =
+                [
+                    new WorksheetDfn
+                    {
+                        Name = "MyFirstSheet",
+                        Rows =
+                        [
+                            new RowDfn
+                            {
+                                Cells =
+                                [
+                                    new CellDfn
+                                    {
+                                        CellDataType = CellDataType.String,
+                                        Value = "Invalid character: \uFFFF",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                Options = new WorkbookDfnOptions { InvalidCharterBehavior = InvalidCharterBehavior.Remove },
+            };
+
+            var fileName = Path.Combine(TempDir, $"{nameof(CanEncodeInvalidXmlCharacters)}.xlsx");
+            using var stream = File.Open(fileName, FileMode.OpenOrCreate);
+            wb.WriteTo(stream);
+        }
+
+        // write another test but this time throw an exception
+        [Fact]
+        public void CanThrowExceptionOnInvalidXmlCharacters()
+        {
+            var wb = new WorkbookDfn
+            {
+                Worksheets =
+                [
+                    new WorksheetDfn
+                    {
+                        Name = "MyFirstSheet",
+                        Rows =
+                        [
+                            new RowDfn
+                            {
+                                Cells =
+                                [
+                                    new CellDfn
+                                    {
+                                        CellDataType = CellDataType.String,
+                                        Value = "Invalid character: \uFFFF",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                Options = new WorkbookDfnOptions { InvalidCharterBehavior = InvalidCharterBehavior.ThrowException },
+            };
+
+            var fileName = Path.Combine(TempDir, $"{nameof(CanThrowExceptionOnInvalidXmlCharacters)}.xlsx");
+            using var stream = File.Open(fileName, FileMode.OpenOrCreate);
+
+            var exception = Assert.Throws<ArgumentException>(() => wb.WriteTo(stream));
+            Assert.Contains("invalid character", exception.Message, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/Clippit.Tests/Excel/Samples/SpreadsheetWriterSamples.cs
+++ b/Clippit.Tests/Excel/Samples/SpreadsheetWriterSamples.cs
@@ -244,49 +244,11 @@ namespace Clippit.Tests.Excel.Samples
                         ],
                     },
                 ],
-                Options = new WorkbookDfnOptions { InvalidCharterBehavior = InvalidCharterBehavior.Remove },
             };
 
             var fileName = Path.Combine(TempDir, $"{nameof(CanEncodeInvalidXmlCharacters)}.xlsx");
             using var stream = File.Open(fileName, FileMode.OpenOrCreate);
             wb.WriteTo(stream);
-        }
-
-        // write another test but this time throw an exception
-        [Fact]
-        public void CanThrowExceptionOnInvalidXmlCharacters()
-        {
-            var wb = new WorkbookDfn
-            {
-                Worksheets =
-                [
-                    new WorksheetDfn
-                    {
-                        Name = "MyFirstSheet",
-                        Rows =
-                        [
-                            new RowDfn
-                            {
-                                Cells =
-                                [
-                                    new CellDfn
-                                    {
-                                        CellDataType = CellDataType.String,
-                                        Value = "Invalid character: \uFFFF",
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                ],
-                Options = new WorkbookDfnOptions { InvalidCharterBehavior = InvalidCharterBehavior.ThrowException },
-            };
-
-            var fileName = Path.Combine(TempDir, $"{nameof(CanThrowExceptionOnInvalidXmlCharacters)}.xlsx");
-            using var stream = File.Open(fileName, FileMode.OpenOrCreate);
-
-            var exception = Assert.Throws<ArgumentException>(() => wb.WriteTo(stream));
-            Assert.Contains("invalid character", exception.Message, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/Clippit/Excel/SpreadsheetWriter.cs
+++ b/Clippit/Excel/SpreadsheetWriter.cs
@@ -213,7 +213,7 @@ namespace Clippit.Excel
         public static void AddWorksheet(
             SpreadsheetDocument sDoc,
             WorksheetDfn worksheetData,
-            WorkbookDfnOptions? options
+            WorkbookDfnOptions? options = default
         )
         {
             var validSheetName = new Regex(@"^[^'*\[\]/\\:?][^*\[\]/\\:?]{0,30}$");


### PR DESCRIPTION
This pull request includes several changes to the `Clippit.Tests/Excel/Samples/SpreadsheetWriterSamples.cs` and `Clippit/Excel/SpreadsheetWriter.cs` files to improve code readability, initialization, and XML handling. The most important changes include the removal of unnecessary `using` statements, the conversion of array initializations to collection initializations, and the addition of a method to sanitize XML strings.

Code readability and initialization improvements:

* [`Clippit.Tests/Excel/Samples/SpreadsheetWriterSamples.cs`](diffhunk://#diff-04d53deef0831bdb2ff42312ff70aac03875fc7f4b55a4d6747ff0deac82c106L1-R21): Removed unnecessary `using` statements and converted array initializations to collection initializations in `Sample1` and `Sample2` methods. [[1]](diffhunk://#diff-04d53deef0831bdb2ff42312ff70aac03875fc7f4b55a4d6747ff0deac82c106L1-R21) [[2]](diffhunk://#diff-04d53deef0831bdb2ff42312ff70aac03875fc7f4b55a4d6747ff0deac82c106L40-R41) [[3]](diffhunk://#diff-04d53deef0831bdb2ff42312ff70aac03875fc7f4b55a4d6747ff0deac82c106L55-R55) [[4]](diffhunk://#diff-04d53deef0831bdb2ff42312ff70aac03875fc7f4b55a4d6747ff0deac82c106R64-R68) [[5]](diffhunk://#diff-04d53deef0831bdb2ff42312ff70aac03875fc7f4b55a4d6747ff0deac82c106L86-R194) [[6]](diffhunk://#diff-04d53deef0831bdb2ff42312ff70aac03875fc7f4b55a4d6747ff0deac82c106R209-R249)

XML handling improvements:

* [`Clippit/Excel/SpreadsheetWriter.cs`](diffhunk://#diff-88509055f71125aab61f6d7b2755b6d328ea4785fd885da425c6036988b095f8L6-R7): Removed unnecessary `using` statements and added `using System.Globalization` and `using System.Text`.
* [`Clippit/Excel/SpreadsheetWriter.cs`](diffhunk://#diff-88509055f71125aab61f6d7b2755b6d328ea4785fd885da425c6036988b095f8L26-R24): Initialized `Worksheets` property with an empty collection in `WorkbookDfn` class.
* [`Clippit/Excel/SpreadsheetWriter.cs`](diffhunk://#diff-88509055f71125aab61f6d7b2755b6d328ea4785fd885da425c6036988b095f8L461-R473): Modified date and time formatting to use `CultureInfo.InvariantCulture` in the `out int numColumns` method.
* [`Clippit/Excel/SpreadsheetWriter.cs`](diffhunk://#diff-88509055f71125aab61f6d7b2755b6d328ea4785fd885da425c6036988b095f8R691-R714): Added `SanitizeXmlString` method to handle invalid XML characters.