### PR TITLE
Modernize CI workflow and update dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,23 +3,30 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "1.2.4",
+      "version": "1.2.6",
       "commands": [
         "csharpier"
       ],
       "rollForward": true
     },
     "husky": {
-      "version": "0.8.0",
+      "version": "0.9.1",
       "commands": [
         "husky"
       ],
       "rollForward": true
     },
     "dotnet-outdated-tool": {
-      "version": "4.6.9",
+      "version": "4.7.1",
       "commands": [
         "dotnet-outdated"
+      ],
+      "rollForward": true
+    },
+    "docfx": {
+      "version": "2.78.5",
+      "commands": [
+        "docfx"
       ],
       "rollForward": true
     }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest, macOS-latest]
+                os: [ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
             - name: Setup .NET SDK
               uses: actions/setup-dotnet@v4
               with:
@@ -34,29 +34,27 @@ jobs:
                   path: bin/*.*
 
     generate-docs:
-        runs-on: windows-latest
+        runs-on: ubuntu-latest
         needs: build
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
             - name: Setup .NET SDK
               uses: actions/setup-dotnet@v4
               with:
                   global-json-file: global.json
-            - name: Build and Test
-              run: dotnet fsi build.fsx -- -p build
-            - name: Setup DocFX
-              uses: crazy-max/ghaction-chocolatey@v1
-              with:
-                  args: install docfx
+            - name: Restore Tools
+              run: dotnet tool restore
+            - name: Restore
+              run: dotnet restore
             - name: DocFX Build
               working-directory: docs
-              run: docfx docfx.json
+              run: dotnet docfx docfx.json
               continue-on-error: false
             - name: Publish
               if: github.event_name == 'push'
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@v4
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: docs/_site

--- a/Clippit.Tests/Clippit.Tests.csproj
+++ b/Clippit.Tests/Clippit.Tests.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\Clippit\Clippit.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="TUnit" Version="1.12.53" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="TUnit" Version="1.19.57" />
   </ItemGroup>
 </Project>

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,12 +4,15 @@
       "src": [
         {
           "files": [
-            "OpenXmlPowerTools/**.csproj"
+            "Clippit/**.csproj"
           ],
           "src": "../"
         }
       ],
       "dest": "api",
+      "properties": {
+        "TargetFramework": "net10.0"
+      },
       "disableGitFeatures": false,
       "disableDefaultFilter": false
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Clippit is a fork of [Open-Xml-PowerTools](https://github.com/EricWhiteDev/Open-
 Key highlights:
 
 - Shipped as new [NuGet package](https://www.nuget.org/packages/Clippit) published from latest `master`.
-- Target `netstandard2.0` and uses latest `C#` language features.
+- Targets `net8.0` and `net10.0` and uses latest `C#` language features.
 - Continuously tested on Windows, macOS and Linux.
 - Can be used side-by-side with any existing Open-Xml-PowerTools assembly.
 
@@ -53,7 +53,7 @@ It supports scenarios such as:
 ```
 Copyright (c) Microsoft Corporation 2012-2017
 Portions Copyright (c) Eric White Inc 2018-2019
-Portions Copyright (c) Sergey Tihon 2019-2025
+Portions Copyright (c) Sergey Tihon 2019-2026
 Licensed under the MIT License.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Key highlights:
 
 - Shipped as new [NuGet package](https://www.nuget.org/packages/Clippit) published from latest `master`.
 - Targets `net8.0` and `net10.0` and uses latest `C#` language features.
-- Continuously tested on Windows, macOS and Linux.
+- Continuously tested on Windows and Linux.
 - Can be used side-by-side with any existing Open-Xml-PowerTools assembly.
 
 Key features:


### PR DESCRIPTION
## Summary

- **Update dotnet tools**: csharpier 1.2.6, husky 0.9.1, dotnet-outdated 4.7.1, add docfx 2.78.5 as a local tool
- **Update test dependencies**: Microsoft.NET.Test.Sdk 18.3.0, TUnit 1.19.57
- **Modernize CI workflow**: actions/checkout v4, peaceiris/actions-gh-pages v4, remove macOS from build matrix, switch generate-docs to ubuntu-latest with `dotnet tool restore` instead of Chocolatey-based DocFX install
- **Fix docfx config**: update stale `OpenXmlPowerTools/**.csproj` reference to `Clippit/**.csproj` (API docs have been silently broken since the rename), add `TargetFramework: net10.0`
- **Update docs metadata**: fix target framework from `netstandard2.0` to `net8.0`/`net10.0`, bump copyright year to 2026