### PR TITLE
Improve documentation with new tutorials and modernized landing page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,8 @@ jobs:
               run: dotnet tool restore
             - name: Restore
               run: dotnet restore
+            - name: Copy CHANGELOG to docs
+              run: cp CHANGELOG.md docs/api/CHANGELOG.md
             - name: DocFX Build
               working-directory: docs
               run: dotnet docfx docfx.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,25 +7,27 @@ Clippit is a .NET library providing OpenXml PowerTools for Word, Excel, and Powe
 
 ### Quick Reference
 
-| Task | Command |
-|------|---------|
-| Full build pipeline | `./build.sh` (Unix) or `.\build.cmd` (Windows) |
-| Build only | `dotnet build Clippit.slnx -c Release` |
-| Restore tools | `dotnet tool restore` |
-| Lint check | `dotnet csharpier check .` |
-| Lint fix | `dotnet csharpier .` |
-| Test all | `dotnet test --project Clippit.Tests/` |
-| Single test | `dotnet test --project Clippit.Tests/ --treenode-filter "/*/*/*/MethodName**"` |
-| Tests in class | `dotnet test --project Clippit.Tests/ --treenode-filter "/*/*/ClassName/**"` |
-| Check outdated deps | `dotnet outdated` |
+| Task                | Command                                                                        |
+| ------------------- | ------------------------------------------------------------------------------ |
+| Full build pipeline | `./build.sh` (Unix) or `.\build.cmd` (Windows)                                 |
+| Build only          | `dotnet build Clippit.slnx -c Release`                                         |
+| Restore tools       | `dotnet tool restore`                                                          |
+| Lint check          | `dotnet csharpier check .`                                                     |
+| Lint fix            | `dotnet csharpier .`                                                           |
+| Test all            | `dotnet test --project Clippit.Tests/`                                         |
+| Single test         | `dotnet test --project Clippit.Tests/ --treenode-filter "/*/*/*/MethodName**"` |
+| Tests in class      | `dotnet test --project Clippit.Tests/ --treenode-filter "/*/*/ClassName/**"`   |
+| Check outdated deps | `dotnet outdated`                                                              |
 
 ### Build Pipeline
 
-The full build script (`build.sh`/`build.cmd`) runs these stages in order:
+The full build script (`build.sh`/`build.cmd`) calls `dotnet fsi build.fsx -- -p build`,
+which runs these stages in order:
+
 1. `dotnet tool restore` and `dotnet restore`
 2. `dotnet csharpier check .` (formatting check — build fails if violated)
 3. `dotnet clean` and clean `bin/`
-4. Generate `Clippit/Properties/AssemblyInfo.g.cs`
+4. Generate `Clippit/Properties/AssemblyInfo.g.cs` (version from `CHANGELOG.md`)
 5. `dotnet build Clippit.slnx -c Release`
 6. `dotnet test --solution Clippit.slnx`
 7. `dotnet pack Clippit/Clippit.csproj -o bin/`
@@ -45,12 +47,14 @@ filter syntax — the pattern `/*/*/*/MethodName**` matches any test method star
 ```
 Clippit/                    Main library (targets net8.0 + net10.0)
   Word/                     Word/DOCX: DocumentBuilder, DocumentAssembler, WmlComparer, HtmlConverter
+    Assembler/              DocumentAssembler helpers (templates, extensions)
   PowerPoint/               PPTX: PresentationBuilder, Fluent API
   Excel/                    XLSX: SpreadsheetWriter, SmlDataRetriever
-  Html/                     HTML-to-WML conversion
-  Comparer/                 WmlComparer (partial classes split across many files)
+  Html/                     HTML-to-WML conversion (CssParser, CssApplier)
+  Comparer/                 WmlComparer (partial classes split across ~26 files by concern)
   Core/                     PowerToolsBlock, StronglyTypedBlock
   Internal/                 ColorParser, TextReplacer, Relationships
+  Properties/               AssemblyInfo.cs (InternalsVisibleTo), AssemblyInfo.g.cs (generated)
 Clippit.Tests/              Test project (targets net10.0)
   Word/ PowerPoint/ Excel/ Html/ Common/    Mirror library structure
   */Samples/                                Sample/integration tests
@@ -84,14 +88,14 @@ Directory.Build.props       Shared MSBuild props (nullable, implicit usings, lan
 
 ### Naming Conventions
 
-| Symbol | Convention | Example |
-|--------|-----------|---------|
-| Types, methods, properties | PascalCase | `DocumentBuilder`, `GetMetrics()` |
-| Constants, enum members | PascalCase | `MaxRetries`, `Landscape` |
-| Local functions | PascalCase | `ProcessElement()` |
-| Private static fields | `s_` + camelCase | `s_tempDir`, `s_maxId` |
-| Private instance fields | `_` + camelCase | `_package`, `_validator` |
-| Locals, parameters | camelCase | `sourceDoc`, `partUri` |
+| Symbol                     | Convention       | Example                           |
+| -------------------------- | ---------------- | --------------------------------- |
+| Types, methods, properties | PascalCase       | `DocumentBuilder`, `GetMetrics()` |
+| Constants, enum members    | PascalCase       | `MaxRetries`, `Landscape`         |
+| Local functions            | PascalCase       | `ProcessElement()`                |
+| Private static fields      | `s_` + camelCase | `s_tempDir`, `s_maxId`            |
+| Private instance fields    | `_` + camelCase  | `_package`, `_validator`          |
+| Locals, parameters         | camelCase        | `sourceDoc`, `partUri`            |
 
 Avoid `this.` qualification for field/property/method access.
 
@@ -105,6 +109,7 @@ Avoid `this.` qualification for field/property/method access.
 ### Modern C# Patterns
 
 Prefer modern C# idioms wherever applicable:
+
 - Object and collection initializers
 - Null coalescing (`??`) and null propagation (`?.`)
 - Pattern matching (`is`, `switch` expressions) over `as` + null check
@@ -115,9 +120,10 @@ Prefer modern C# idioms wherever applicable:
 
 ### Error Handling
 
-- Warnings are **not** treated as errors (`TreatWarningsAsErrors: false`)
+- `AnalysisMode` is `All` but warnings are **not** treated as errors
 - Use project-specific exceptions: `OpenXmlPowerToolsException`,
-  `PowerToolsDocumentException`, `InvalidOpenXmlDocumentException`
+  `PowerToolsDocumentException`, `InvalidOpenXmlDocumentException`,
+  `DocumentBuilderException`, `PresentationBuilderException`
 - Guard clauses: prefer `ArgumentNullException.ThrowIfNull(param)` for null checks
 - No logging framework — the library does not log; tests use `Console.WriteLine`
 
@@ -132,12 +138,13 @@ Prefer modern C# idioms wherever applicable:
 
 - Testing framework: **TUnit** — use `[Test]` and `[Arguments]` attributes
 - Assertions are async and fluent:
-  ```csharp
-  await Assert.That(errors).IsEmpty();
-  await Assert.That(value).IsEqualTo(expected);
-  await Assert.That(collection).HasCount(5);
-  await Assert.That(() => action).Throws<OpenXmlPowerToolsException>();
-  ```
+
+    ```csharp
+    await Assert.That(errors).IsEmpty();
+    await Assert.That(value).IsEqualTo(expected);
+    await Assert.That(collection).HasCount(5);
+    await Assert.That(() => action).Throws<OpenXmlPowerToolsException>();
+    ```
 
 ### Test Structure
 
@@ -156,9 +163,10 @@ Prefer modern C# idioms wherever applicable:
 
 ## Key Architecture Notes
 
-- **Partial classes**: `WmlComparer` is split across many files by concern
-  (e.g., `WmlComparer.Private.Methods.Hashing.cs`)
+- **Partial classes**: `WmlComparer` is split across ~26 files by concern
+  (e.g., `WmlComparer.Public.Methods.Compare.cs`, `WmlComparer.Private.Methods.Hashing.cs`)
 - **Extension methods**: `PtOpenXmlExtensions`, `PtExtensions` extend OpenXml SDK types
 - **XNamespace constants**: `W`, `WP`, `M`, `MC`, etc. in `PtOpenXmlUtil.cs` define
   all XML namespace constants used throughout the library
+- **Versioning**: version is derived from `CHANGELOG.md` by the build script
 - **No new dependencies** without clear justification — the project values minimal deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,7 @@
 
 ## [1.7.1] - Aug 18, 2021
 
-- Resolving bug with nested rowspans [335](https://github.com/sergey-tihon/Clippit/pull/35)
+- Resolving bug with nested rowspans [#35](https://github.com/sergey-tihon/Clippit/pull/35)
 
 ## [1.7.0] - Aug 15, 2021
 
@@ -211,7 +211,7 @@
 
 ## [1.4.0] - Feb 10, 2021
 
-- DocumentBuilder: Added ISource and TableCellSource] - [#17](https://github.com/sergey-tihon/Clippit/pull/17)
+- DocumentBuilder: Added ISource and TableCellSource - [#17](https://github.com/sergey-tihon/Clippit/pull/17)
 - DocumentFormat.OpenXml (2.12.1)
 - Added dependency on System.IO.Packaging
 - Fixed DateTime/DateTimeOffset serialisation format to Excel

--- a/Clippit/OpenXmlRegex.cs
+++ b/Clippit/OpenXmlRegex.cs
@@ -68,15 +68,15 @@ namespace Clippit
         }
 
         /// <summary>
-        /// If replacement == "new content" && callback == null
-        ///     Then replaces all matches
-        /// If replacement == "" && callback == null)
-        ///     Then deletes all matches
-        /// If replacement == "new content" && callback != null)
-        ///     Then the callback can return true / false to indicate whether to replace or not
+        /// If replacement == "new content" and callback == null,
+        ///     then replaces all matches.
+        /// If replacement == "" and callback == null,
+        ///     then deletes all matches.
+        /// If replacement == "new content" and callback != null,
+        ///     then the callback can return true / false to indicate whether to replace or not.
         /// If the callback returns true once, and false on all subsequent calls, then this method replaces only the first found.
-        /// If replacement == "" && callback != null)
-        ///     Then the callback can return true / false to indicate whether to delete or not
+        /// If replacement == "" and callback != null,
+        ///     then the callback can return true / false to indicate whether to delete or not.
         /// </summary>
         public static int Replace(
             IEnumerable<XElement> content,
@@ -103,19 +103,19 @@ namespace Clippit
         }
 
         /// <summary>
-        /// If replacement == "new content" && callback == null
-        ///     Then replaces all matches
-        /// If replacement == "" && callback == null)
-        ///     Then deletes all matches
-        /// If replacement == "new content" && callback != null)
-        ///     Then the callback can return true / false to indicate whether to replace or not
+        /// If replacement == "new content" and callback == null,
+        ///     then replaces all matches.
+        /// If replacement == "" and callback == null,
+        ///     then deletes all matches.
+        /// If replacement == "new content" and callback != null,
+        ///     then the callback can return true / false to indicate whether to replace or not.
         /// If the callback returns true once, and false on all subsequent calls, then this method replaces only the first found.
-        /// If replacement == "" && callback != null)
-        ///     Then the callback can return true / false to indicate whether to delete or not
-        /// If trackRevisions == true
-        ///     Then replacement is done using revision tracking markup, with author as the revision tracking author
-        /// If trackRevisions == true for a PPTX
-        ///     Then code throws an exception
+        /// If replacement == "" and callback != null,
+        ///     then the callback can return true / false to indicate whether to delete or not.
+        /// If trackRevisions == true,
+        ///     then replacement is done using revision tracking markup, with author as the revision tracking author.
+        /// If trackRevisions == true for a PPTX,
+        ///     then code throws an exception.
         /// </summary>
         public static int Replace(
             IEnumerable<XElement> content,

--- a/README.md
+++ b/README.md
@@ -10,9 +10,5 @@ Run `./build.sh` on Unix systems or `.\build.cmd` on Windows.
 
 ### Documentation
 
-- Install DocFx
-
-  - MacOS: `brew install docfx`
-  - Windows : `choco install docfx -y`
-
-- Run `docfx docs/docfx.json --serve` to start local copy of site/docs.
+- Run `dotnet tool restore` to install DocFX as a local tool.
+- Run `dotnet docfx docs/docfx.json --serve` to start local copy of site/docs.

--- a/build.fsx
+++ b/build.fsx
@@ -45,7 +45,9 @@ pipeline "build" {
                   AssemblyInfo.Product "Clippit"
                   AssemblyInfo.Description "Fresh PowerTools for OpenXml"
                   AssemblyInfo.Version version.Version
-                  AssemblyInfo.FileVersion version.Version ])
+                  AssemblyInfo.FileVersion version.Version ]
+
+            Shell.copyFile "docs/api/CHANGELOG.md" "CHANGELOG.md")
     }
 
     stage "Build" { run "dotnet build Clippit.slnx -c Release" }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,54 +1,93 @@
-# Clippit - fresh PowerTools for OpenXml
+# Clippit — Fresh PowerTools for OpenXml
 
-[![NuGet Badge](https://buildstats.info/nuget/Clippit)](https://www.nuget.org/packages/Clippit) [![Build Status](https://github.com/sergey-tihon/Clippit/workflows/Build%20and%20Test/badge.svg?branch=master)](https://github.com/sergey-tihon/Clippit/actions?query=branch%3Amaster)
+![NuGet Version](https://badgen.net/nuget/v/Clippit) ![NuGet Downloads](https://badgen.net/nuget/dt/Clippit)
 
 <img style="float: right;" src="images/logo.jpeg">
 
-## Why Clippit?
+Clippit is a .NET library for programmatically creating, modifying, and converting
+Word (DOCX), Excel (XLSX), and PowerPoint (PPTX) documents. Built on top of the
+[Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK), it provides high-level
+APIs that handle the complexity of the Open XML format so you can focus on your content.
 
-Clippit is a fork of [Open-Xml-PowerTools](https://github.com/EricWhiteDev/Open-Xml-PowerTools) (currently owned by Eric White) with new features, fixes and performance optimizations.
+## Getting Started
 
-Key highlights:
+Install from NuGet:
 
-- Shipped as new [NuGet package](https://www.nuget.org/packages/Clippit) published from latest `master`.
-- Targets `net8.0` and `net10.0` and uses latest `C#` language features.
-- Continuously tested on Windows and Linux.
-- Can be used side-by-side with any existing Open-Xml-PowerTools assembly.
+```bash
+dotnet add package Clippit
+```
 
-Key features:
+Split a PowerPoint presentation into individual slides:
 
-- Provides optimized [slide publishing API](xref:Tutorial.Word.PresentationBuilder.PublishSlides) and improved [PresentationBuilder](xref:Tutorial.Word.PresentationBuilder)
-- [ISource extensibility model](xref:Tutorial.Word.DocumentBuilder.ISource) for DocumentBuilder and new [TableCellSource](xref:Tutorial.Word.DocumentBuilder.TableCellSource).
-- [SpreadsheetWriter](xref:Tutorial.Excel.SpreadsheetWriter) that is able to generate multi-spreadsheet Excel files with data formatted as table and compatible with Power BI.
+```csharp
+using Clippit.PowerPoint;
 
-Most of existing content about Open-Xml-PowerTools is still relevant:
+var presentation = new PmlDocument("conference-deck.pptx");
+var slides = PresentationBuilder.PublishSlides(presentation);
 
-- [DocumentBuilder Resource Center](https://www.ericwhite.com/blog/documentbuilder-developer-center/)
-- [PresentationBuilder Resource Center](https://www.ericwhite.com/blog/presentationbuilder-developer-center/)
-- [WmlToHtmlConverter Resource Center](https://www.ericwhite.com/blog/wmltohtmlconverter-developer-center/)
-- [DocumentAssembler Resource Center](https://www.ericwhite.com/blog/documentassembler-developer-center/)
+foreach (var slide in slides)
+{
+    slide.SaveAs(Path.Combine("output", slide.FileName));
+}
+```
 
-## About Open-XML-PowerTools
+## Features
 
-The Open XML PowerTools provides guidance and example code for programming with Open XML
-Documents (DOCX, XLSX, and PPTX). It is based on, and extends the functionality
-of the [Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK).
+Clippit covers a broad range of document processing scenarios across all three
+Office formats. Every feature listed below has a dedicated tutorial with API
+signatures and code samples.
 
-It supports scenarios such as:
+### Word
 
-- Splitting DOCX/PPTX files into multiple files.
-- Combining multiple DOCX/PPTX files into a single file.
-- Populating content in template DOCX files with data from XML.
-- High-fidelity conversion of DOCX to HTML/CSS.
-- High-fidelity conversion of HTML/CSS to DOCX.
-- Searching and replacing content in DOCX/PPTX using regular expressions.
-- Managing tracked-revisions, including detecting tracked revisions, and accepting tracked revisions.
-- Updating Charts in DOCX/PPTX files, including updating cached data, as well as the embedded XLSX.
-- Comparing two DOCX files, producing a DOCX with revision tracking markup, and enabling retrieving a list of revisions.
-- Retrieving metrics from DOCX files, including the hierarchy of styles used, the languages used, and the fonts used.
-- Writing XLSX files using far simpler code than directly writing the markup, including a streaming approach that
-  enables writing XLSX files with millions of rows.
-- Extracting data (along with formatting) from spreadsheets.
+| Feature                                                                     | Description                                                                                                                                                                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [DocumentAssembler](xref:Tutorial.Word.DocumentAssembler.DocumentTemplates) | Populate DOCX templates with data from XML, including [images](xref:Tutorial.Word.DocumentAssembler.ImagesSupport) and [inline HTML](xref:Tutorial.Word.DocumentAssembler.InlineHtmlSupport)     |
+| [DocumentBuilder](xref:Tutorial.Word.DocumentBuilder.ISource)               | Merge, split, and reorganize DOCX files with an [extensible ISource model](xref:Tutorial.Word.DocumentBuilder.ISource) and [TableCellSource](xref:Tutorial.Word.DocumentBuilder.TableCellSource) |
+| [WmlComparer](xref:Tutorial.Word.WmlComparer)                               | Compare two DOCX files and produce a diff with revision tracking markup                                                                                                                          |
+| [WmlToHtmlConverter](xref:Tutorial.Word.WmlToHtmlConverter)                 | High-fidelity conversion from DOCX to HTML/CSS                                                                                                                                                   |
+| [HtmlToWmlConverter](xref:Tutorial.Word.HtmlToWmlConverter)                 | Convert HTML/CSS back into a properly structured DOCX                                                                                                                                            |
+| [RevisionProcessor](xref:Tutorial.Word.RevisionProcessor)                   | Accept or reject tracked revisions programmatically                                                                                                                                              |
+| [MarkupSimplifier](xref:Tutorial.Word.MarkupSimplifier)                     | Clean up and normalize DOCX markup for easier processing                                                                                                                                         |
+
+### Excel
+
+| Feature                                                    | Description                                                                                                                   |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [SpreadsheetWriter](xref:Tutorial.Excel.SpreadsheetWriter) | Generate multi-sheet XLSX files with formatted tables, streaming support for millions of rows, and a concise Cell Builder API |
+| [SmlDataRetriever](xref:Tutorial.Excel.SmlDataRetriever)   | Extract data and formatting from existing spreadsheets as structured XML                                                      |
+
+### PowerPoint
+
+| Feature                                                             | Description                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [PresentationBuilder](xref:Tutorial.PowerPoint.PresentationBuilder) | Merge and split PPTX files, with a [Fluent API](xref:Tutorial.PowerPoint.BuildPresentation.FluentApi) for ergonomic slide composition and optimized [slide publishing](xref:Tutorial.PowerPoint.PresentationBuilder.PublishSlides) |
+
+### Common
+
+| Feature                                             | Description                                                             |
+| --------------------------------------------------- | ----------------------------------------------------------------------- |
+| [OpenXmlRegex](xref:Tutorial.Common.OpenXmlRegex)   | Search and replace content across DOCX/PPTX using regular expressions   |
+| [MetricsGetter](xref:Tutorial.Common.MetricsGetter) | Retrieve document metrics — style hierarchy, languages, fonts, and more |
+
+## Compatibility
+
+- **Targets:** `net8.0` and `net10.0`
+- **Dependency:** [DocumentFormat.OpenXml](https://www.nuget.org/packages/DocumentFormat.OpenXml) (Open XML SDK)
+- **Platforms:** Windows and Linux (continuously tested on both)
+- **Side-by-side:** Can coexist with the original Open-Xml-PowerTools assembly
+
+## Heritage
+
+Clippit originated as a fork of [Open-Xml-PowerTools](https://github.com/EricWhiteDev/Open-Xml-PowerTools)
+and has since evolved into an independently maintained library with new features,
+performance improvements, and modern .NET support. See the
+[Changelog](api/CHANGELOG.md) for the full release history.
+
+## Questions and Contributing
+
+Have a question or idea? Start a [GitHub Discussion](https://github.com/sergey-tihon/Clippit/discussions).
+
+Found a bug or want to request a feature? Open an [Issue](https://github.com/sergey-tihon/Clippit/issues).
 
 ```
 Copyright (c) Microsoft Corporation 2012-2017
@@ -56,4 +95,3 @@ Portions Copyright (c) Eric White Inc 2018-2019
 Portions Copyright (c) Sergey Tihon 2019-2026
 Licensed under the MIT License.
 ```
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,10 +23,10 @@ Key features:
 
 Most of existing content about Open-Xml-PowerTools is still relevant:
 
-- [DocumentBuilder Resource Center](http://www.ericwhite.com/blog/documentbuilder-developer-center/)
-- [PresentationBuilder Resource Center](http://www.ericwhite.com/blog/presentationbuilder-developer-center/)
-- [WmlToHtmlConverter Resource Center](http://www.ericwhite.com/blog/wmltohtmlconverter-developer-center/)
-- [DocumentAssembler Resource Center](http://www.ericwhite.com/blog/documentassembler-developer-center/)
+- [DocumentBuilder Resource Center](https://www.ericwhite.com/blog/documentbuilder-developer-center/)
+- [PresentationBuilder Resource Center](https://www.ericwhite.com/blog/presentationbuilder-developer-center/)
+- [WmlToHtmlConverter Resource Center](https://www.ericwhite.com/blog/wmltohtmlconverter-developer-center/)
+- [DocumentAssembler Resource Center](https://www.ericwhite.com/blog/documentassembler-developer-center/)
 
 ## About Open-XML-PowerTools
 

--- a/docs/tutorials/common/MetricsGetter.md
+++ b/docs/tutorials/common/MetricsGetter.md
@@ -1,0 +1,90 @@
+---
+uid: Tutorial.Common.MetricsGetter
+---
+# Document Metrics
+
+Namespace: `Clippit`
+
+Analyze Word, Excel, and PowerPoint documents and return detailed metrics as XML.
+
+```csharp
+public class MetricsGetter {
+    public static XElement GetMetrics(string fileName, MetricsGetterSettings settings)
+    {...}
+
+    public static XElement GetDocxMetrics(WmlDocument wmlDoc, MetricsGetterSettings settings)
+    {...}
+
+    public static XElement GetXlsxMetrics(SmlDocument smlDoc, MetricsGetterSettings settings)
+    {...}
+
+    public static XElement GetPptxMetrics(PmlDocument pmlDoc, MetricsGetterSettings settings)
+    {...}
+}
+```
+
+`MetricsGetter` inspects Office documents and produces an `XElement` containing metrics such as
+paragraph counts, character counts (by script), run counts, content control details, embedded
+objects, hyperlinks, revision tracking status, namespaces, and validation errors.
+
+The `GetMetrics` method auto-detects the file type by extension and delegates to
+`GetDocxMetrics`, `GetXlsxMetrics`, or `GetPptxMetrics`.
+
+### MetricsGetterSettings
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `IncludeTextInContentControls` | `bool` | `false` | Include text content of content controls in output |
+| `IncludeXlsxTableCellData` | `bool` | `false` | Include cell data from Excel tables |
+| `RetrieveNamespaceList` | `bool` | `false` | Include list of namespaces used in the document |
+| `RetrieveContentTypeList` | `bool` | `false` | Include list of content types of document parts |
+
+### GetMetrics Sample
+
+```csharp
+var settings = new MetricsGetterSettings
+{
+    RetrieveNamespaceList = true,
+    RetrieveContentTypeList = true
+};
+
+var metrics = MetricsGetter.GetMetrics("document.docx", settings);
+Console.WriteLine(metrics.ToString());
+```
+
+Output includes elements such as:
+- `ParagraphCount`, `RunCount`, `AsciiCharCount`, `EastAsiaCharCount`
+- `RevisionTracking` (whether the document has tracked revisions)
+- `ContentControls` (if present)
+- `Namespaces` (if `RetrieveNamespaceList` is `true`)
+- Validation errors from the OpenXml SDK validator
+
+### GetDocxMetrics Sample
+
+```csharp
+var wmlDoc = new WmlDocument("report.docx");
+var settings = new MetricsGetterSettings
+{
+    IncludeTextInContentControls = true
+};
+
+var metrics = MetricsGetter.GetDocxMetrics(wmlDoc, settings);
+
+// Extract specific values
+var paragraphCount = (int?)metrics.Element("ParagraphCount");
+var hasRevisions = (bool?)metrics.Element("RevisionTracking")?.Attribute("Val");
+Console.WriteLine($"Paragraphs: {paragraphCount}, Has revisions: {hasRevisions}");
+```
+
+### GetXlsxMetrics Sample
+
+```csharp
+var smlDoc = new SmlDocument("data.xlsx");
+var settings = new MetricsGetterSettings
+{
+    IncludeXlsxTableCellData = true
+};
+
+var metrics = MetricsGetter.GetXlsxMetrics(smlDoc, settings);
+Console.WriteLine(metrics.ToString());
+```

--- a/docs/tutorials/common/OpenXmlRegex.md
+++ b/docs/tutorials/common/OpenXmlRegex.md
@@ -1,0 +1,100 @@
+---
+uid: Tutorial.Common.OpenXmlRegex
+---
+# OpenXml Regex
+
+Namespace: `Clippit`
+
+Search and replace text in Word and PowerPoint documents using regular expressions,
+with optional revision tracking support.
+
+```csharp
+public class OpenXmlRegex {
+    public static int Match(IEnumerable<XElement> content, Regex regex)
+    {...}
+
+    public static int Match(
+        IEnumerable<XElement> content, Regex regex, Action<XElement, Match> found)
+    {...}
+
+    public static int Replace(
+        IEnumerable<XElement> content, Regex regex, string replacement,
+        Func<XElement, Match, bool> doReplacement)
+    {...}
+
+    public static int Replace(
+        IEnumerable<XElement> content, Regex regex, string replacement,
+        Func<XElement, Match, bool> doReplacement, bool coalesceContent)
+    {...}
+
+    public static int Replace(
+        IEnumerable<XElement> content, Regex regex, string replacement,
+        Func<XElement, Match, bool> doReplacement,
+        bool trackRevisions, string author)
+    {...}
+}
+```
+
+`OpenXmlRegex` works on paragraph-level content elements (Word `w:p` and PowerPoint `a:p` elements).
+It consolidates runs within each paragraph into a single logical string, applies the regex, and then
+reconstructs the runs preserving original formatting.
+
+#### Key Features
+
+- **Works across runs** -- text split across multiple runs is matched as a single string
+- **Preserves formatting** -- replaced text inherits the formatting of the first matched run
+- **Revision tracking** -- replacements in Word content can generate tracked changes
+  with a specified author (not supported for PowerPoint)
+- **Callback control** -- the `doReplacement` callback controls whether each match is
+  replaced, enabling selective replacement (e.g., replace only the first match)
+
+### Match Sample
+
+```csharp
+using var doc = WordprocessingDocument.Open("input.docx", false);
+var body = doc.MainDocumentPart.GetXDocument().Root.Element(W.body);
+var paragraphs = body.Descendants(W.p);
+
+var regex = new Regex(@"\b\d{3}-\d{2}-\d{4}\b"); // SSN pattern
+
+// Count matches
+var count = OpenXmlRegex.Match(paragraphs, regex);
+Console.WriteLine($"Found {count} matches");
+
+// Inspect each match
+OpenXmlRegex.Match(paragraphs, regex, (element, match) =>
+{
+    Console.WriteLine($"Found: {match.Value}");
+});
+```
+
+### Replace Sample
+
+```csharp
+var wmlDoc = new WmlDocument("input.docx");
+using var streamDoc = new OpenXmlMemoryStreamDocument(wmlDoc);
+using var doc = streamDoc.GetWordprocessingDocument();
+var body = doc.MainDocumentPart.GetXDocument().Root.Element(W.body);
+var paragraphs = body.Descendants(W.p).ToList();
+
+var regex = new Regex(@"PLACEHOLDER");
+var replacementCount = OpenXmlRegex.Replace(
+    paragraphs, regex, "Actual Value", null);
+doc.MainDocumentPart.PutXDocument();
+
+Console.WriteLine($"Replaced {replacementCount} occurrences");
+```
+
+### Replace with Revision Tracking
+
+```csharp
+var regex = new Regex(@"old text");
+OpenXmlRegex.Replace(
+    paragraphs,
+    regex,
+    "new text",
+    doReplacement: null,
+    trackRevisions: true,
+    author: "Auto-Replace Tool"
+);
+```

--- a/docs/tutorials/common/toc.yml
+++ b/docs/tutorials/common/toc.yml
@@ -1,0 +1,4 @@
+- name: MetricsGetter
+  href: MetricsGetter.md
+- name: OpenXmlRegex
+  href: OpenXmlRegex.md

--- a/docs/tutorials/excel/SmlDataRetriever.md
+++ b/docs/tutorials/excel/SmlDataRetriever.md
@@ -1,0 +1,85 @@
+---
+uid: Tutorial.Excel.SmlDataRetriever
+---
+# Retrieve Spreadsheet Data
+
+Namespace: `Clippit.Excel`
+
+Extract sheet data, named ranges, and table data from Excel documents as XML.
+
+```csharp
+public static class SmlDataRetriever {
+    public static XElement RetrieveSheet(SmlDocument smlDoc, string sheetName)
+    {...}
+    public static XElement RetrieveSheet(string fileName, string sheetName)
+    {...}
+    public static XElement RetrieveSheet(SpreadsheetDocument sDoc, string sheetName)
+    {...}
+
+    public static XElement RetrieveRange(SmlDocument smlDoc, string sheetName, string range)
+    {...}
+    public static XElement RetrieveRange(
+        SmlDocument smlDoc, string sheetName,
+        int leftColumn, int topRow, int rightColumn, int bottomRow)
+    {...}
+
+    public static XElement RetrieveTable(SmlDocument smlDoc, string sheetName, string tableName)
+    {...}
+
+    public static string[] SheetNames(SmlDocument smlDoc)
+    {...}
+    public static string[] TableNames(SmlDocument smlDoc)
+    {...}
+}
+```
+
+`SmlDataRetriever` reads Excel data and returns it as `XElement` trees. Cell values are resolved
+(including shared strings), and formatting information is preserved. Each method has overloads
+accepting `SmlDocument`, `string` (file path), or `SpreadsheetDocument`.
+
+#### Key Features
+
+- **Full sheet retrieval** -- get all data from a named worksheet
+- **Range retrieval** -- extract a specific cell range by address (e.g., `"A1:D10"`) or by column/row coordinates
+- **Table retrieval** -- extract data from named Excel tables
+- **Discovery** -- list all sheet names and table names in a workbook
+
+### RetrieveSheet Sample
+
+```csharp
+var smlDoc = new SmlDocument("data.xlsx");
+
+var sheetNames = SmlDataRetriever.SheetNames(smlDoc);
+Console.WriteLine($"Sheets: {string.Join(", ", sheetNames)}");
+
+var sheetData = SmlDataRetriever.RetrieveSheet(smlDoc, sheetNames[0]);
+Console.WriteLine(sheetData.ToString());
+```
+
+### RetrieveRange Sample
+
+```csharp
+var smlDoc = new SmlDocument("data.xlsx");
+
+// By cell address range
+var rangeData = SmlDataRetriever.RetrieveRange(smlDoc, "Sheet1", "A1:C10");
+
+// By column/row coordinates (1-based)
+var rangeData2 = SmlDataRetriever.RetrieveRange(
+    smlDoc, "Sheet1",
+    leftColumn: 1, topRow: 1, rightColumn: 3, bottomRow: 10);
+```
+
+### RetrieveTable Sample
+
+```csharp
+var smlDoc = new SmlDocument("data.xlsx");
+
+var tableNames = SmlDataRetriever.TableNames(smlDoc);
+foreach (var tableName in tableNames)
+{
+    var tableData = SmlDataRetriever.RetrieveTable(smlDoc, "Sheet1", tableName);
+    Console.WriteLine($"Table: {tableName}");
+    Console.WriteLine(tableData.ToString());
+}
+```

--- a/docs/tutorials/excel/SpreadsheetWriter.md
+++ b/docs/tutorials/excel/SpreadsheetWriter.md
@@ -18,7 +18,55 @@ public static class SpreadsheetWriter {
 
 - Added API to save to stream.
 
-### SpreadsheetWriter Sample
+### Cell Builder
+
+The `Clippit.Excel.Builder` namespace provides a `Cell` static class with factory methods
+for concise cell creation:
+
+| Method | Returns | Description |
+|---|---|---|
+| `Cell.Headers(params string[])` | `CellDfn[]` | Bold string cells for column headings |
+| `Cell.String(string, bool bold = false)` | `CellDfn` | String cell (auto-strips invalid XML chars) |
+| `Cell.Number(int)` / `Cell.Number(long)` | `CellDfn` | Numeric cell |
+| `Cell.Bool(bool?)` | `CellDfn` | Boolean cell |
+| `Cell.Date(DateTime?)` | `CellDfn` | Date cell with `mm-dd-yy` format |
+
+### SpreadsheetWriter Sample (Cell Builder)
+
+```csharp
+using Clippit.Excel;
+using Clippit.Excel.Builder;
+
+var wb = new WorkbookDfn
+{
+    Worksheets =
+    [
+        new WorksheetDfn
+        {
+            Name = "MyFirstSheet",
+            TableName = "NamesAndRates",
+            ColumnHeadings = Cell.Headers("Name", "Age", "Rate"),
+            Rows =
+            [
+                new RowDfn
+                {
+                    Cells = [Cell.String("Eric"), Cell.Number(50), Cell.Number(45)]
+                },
+                new RowDfn
+                {
+                    Cells = [Cell.String("Bob"), Cell.Number(42), Cell.Number(78)]
+                },
+            ]
+        }
+    ]
+};
+
+using var stream = new MemoryStream();
+wb.WriteTo(stream);
+var bytes = stream.ToArray();
+```
+
+### SpreadsheetWriter Sample (Object Initializers)
 
 ```csharp 
 var wb = new WorkbookDfn()

--- a/docs/tutorials/excel/toc.yml
+++ b/docs/tutorials/excel/toc.yml
@@ -1,2 +1,4 @@
+- name: SmlDataRetriever
+  href: SmlDataRetriever.md
 - name: SpreadsheetWriter
   href: SpreadsheetWriter.md

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,11 +8,9 @@ Welcome to Clippit library usage guide. If you don't know what Clippit is - plea
 Please check navigation on the left ⬅ for more articles.
 
 ### Requirements
-Clippit library should work with any framework version supported by [.NET Standard 2.0](https://docs.microsoft.com/en-gb/dotnet/standard/net-standard) or greater. However, it is guaranteed only with .NET 5 and up - I did not test .NET Framework, Mono, Xamarin or Unity.
+Clippit targets `net8.0` and `net10.0`. It requires .NET 8.0 or later.
 
 ## Questions?
 To ask questions or share ideas, feel free to start a new [GitHub Discussion](https://github.com/sergey-tihon/Clippit/discussions).
 
 Any bugs? Requesting a specific feature? Please create a new [Issue on GitHub](https://github.com/sergey-tihon/Clippit/issues).
-
-To contact me directly, you can find me on [Twitter](https://twitter.com/sergey_tihon). 

--- a/docs/tutorials/powerpoint/BuildPresentation.md
+++ b/docs/tutorials/powerpoint/BuildPresentation.md
@@ -1,5 +1,5 @@
 ---
-uid: Tutorial.Word.PresentationBuilder
+uid: Tutorial.PowerPoint.PresentationBuilder
 ---
 # Build Presentation
 

--- a/docs/tutorials/powerpoint/BuildPresentation.md
+++ b/docs/tutorials/powerpoint/BuildPresentation.md
@@ -16,7 +16,7 @@ public static class PresentationBuilder {
 
 Original behavior is documented at Eric's blog:
 
-http://www.ericwhite.com/blog/presentationbuilder-developer-center/
+https://www.ericwhite.com/blog/presentationbuilder-developer-center/
 
 #### Major changes
 

--- a/docs/tutorials/powerpoint/BuildPresentation_FluentApi.md
+++ b/docs/tutorials/powerpoint/BuildPresentation_FluentApi.md
@@ -1,0 +1,68 @@
+---
+uid: Tutorial.PowerPoint.BuildPresentation.FluentApi
+---
+# Fluent Presentation Builder
+
+Namespace: `Clippit.PowerPoint`
+
+Build PowerPoint presentations incrementally by adding individual slide master parts and slide parts
+using a fluent API pattern.
+
+```csharp
+public static partial class PresentationBuilder {
+    public static IFluentPresentationBuilder Create(PresentationDocument document)
+    {...}
+
+    public static PresentationDocument NewDocument(Stream stream)
+    {...}
+}
+
+public interface IFluentPresentationBuilder : IDisposable {
+    SlideMasterPart AddSlideMasterPart(SlideMasterPart slideMasterPart);
+    SlidePart AddSlidePart(SlidePart slidePart);
+}
+```
+
+Unlike `BuildPresentation` which combines `SlideSource` collections in a single call,
+the fluent API allows you to build a presentation by adding parts one at a time.
+This is useful when slides come from different sources or are assembled dynamically.
+
+#### Key Features
+
+- **Incremental construction** -- add slides one at a time as they become available
+- **Part-level control** -- add slide masters and slides independently
+- **Structural deduplication** -- themes, masters, and layouts are structurally compared
+  and deduplicated, maintaining minimal parts in the target presentation
+- **Shape auto-scaling** -- shapes are automatically scaled when merging slides of different sizes
+
+### FluentPresentationBuilder Sample
+
+```csharp
+using var stream = new MemoryStream();
+using var targetDoc = PresentationBuilder.NewDocument(stream);
+using var builder = PresentationBuilder.Create(targetDoc);
+
+// Open source presentations
+using var source1 = PresentationDocument.Open("presentation1.pptx", false);
+using var source2 = PresentationDocument.Open("presentation2.pptx", false);
+
+// Add a slide master from the first presentation
+var masterPart = source1.PresentationPart.SlideMasterParts.First();
+builder.AddSlideMasterPart(masterPart);
+
+// Add individual slides from different sources
+foreach (var slidePart in source1.PresentationPart.SlideParts.Take(3))
+{
+    builder.AddSlidePart(slidePart);
+}
+
+foreach (var slidePart in source2.PresentationPart.SlideParts)
+{
+    builder.AddSlidePart(slidePart);
+}
+
+// Save the result
+targetDoc.Save();
+var result = new PmlDocument("result.pptx", stream.ToArray());
+result.SaveAs("combined.pptx");
+```

--- a/docs/tutorials/powerpoint/BuildPresentation_PublishSlides.md
+++ b/docs/tutorials/powerpoint/BuildPresentation_PublishSlides.md
@@ -1,5 +1,5 @@
 ---
-uid: Tutorial.Word.PresentationBuilder.PublishSlides
+uid: Tutorial.PowerPoint.PresentationBuilder.PublishSlides
 ---
 # Slide Publishing
 

--- a/docs/tutorials/powerpoint/BuildPresentation_PublishSlides.md
+++ b/docs/tutorials/powerpoint/BuildPresentation_PublishSlides.md
@@ -9,7 +9,7 @@ Split PowerPoint presentation (`PmlDocument`) into lazy sequence of one-slide pr
 
 ```csharp
 public static class PresentationBuilder {
-    public static IEnumerable<PmlDocument> PublishSlides(PmlDocument src)
+    public static IList<PmlDocument> PublishSlides(PmlDocument src)
     {...}
 }
 ```
@@ -27,7 +27,7 @@ This is fully managed alternative of [Presentation.PublishSlides](https://docs.m
 
 ```csharp {highlight:[2]}
 var presentation = new PmlDocument(sourcePath);
-var slides = PresentationBuilder.PublishSlides(presentation)
+var slides = PresentationBuilder.PublishSlides(presentation);
 foreach (var slide in slides)
 {
     var targetPath = Path.Combine(targetDir, Path.GetFileName(slide.FileName))

--- a/docs/tutorials/powerpoint/BuildPresentation_PublishSlides.md
+++ b/docs/tutorials/powerpoint/BuildPresentation_PublishSlides.md
@@ -5,7 +5,7 @@ uid: Tutorial.PowerPoint.PresentationBuilder.PublishSlides
 
 Namespace: `Clippit.PowerPoint`
 
-Split PowerPoint presentation (`PmlDocument`) into lazy sequence of one-slide presentations.
+Split PowerPoint presentation (`PmlDocument`) into a list of one-slide presentations.
 
 ```csharp
 public static class PresentationBuilder {

--- a/docs/tutorials/powerpoint/toc.yml
+++ b/docs/tutorials/powerpoint/toc.yml
@@ -1,5 +1,7 @@
 - name: BuildPresentation
   href: BuildPresentation.md
   items:
+  - name: Fluent API
+    href: BuildPresentation_FluentApi.md
   - name: Publish Slides
     href: BuildPresentation_PublishSlides.md

--- a/docs/tutorials/toc.yml
+++ b/docs/tutorials/toc.yml
@@ -1,5 +1,7 @@
 - name: Introduction
   href: index.md
+- name: Common
+  href: common/toc.yml
 - name: Excel
   href: excel/toc.yml
 - name: PowerPoint

--- a/docs/tutorials/word/DocumentAssembler_DocumentTemplates.md
+++ b/docs/tutorials/word/DocumentAssembler_DocumentTemplates.md
@@ -1,8 +1,9 @@
 ---
 uid: Tutorial.Word.DocumentAssembler.DocumentTemplates
 ---
+# Document and DocumentTemplate Elements
 
-# Inserting Documents or Document Templates into Word Files using Document Assembler
+Namespace: `Clippit.Word`
 
 ## Introduction
 
@@ -43,9 +44,9 @@ For example say we had the following XML document:
        <amount>£40.00</amount>
       </line-item>
       <line-item>
-        <description>T-Shirt<description>
+        <description>T-Shirt</description>
         <amount>£15.00</amount>
-      <line-item>
+      </line-item>
     </line-items>
     <total>
       <amount>£55.00</amount>

--- a/docs/tutorials/word/DocumentAssembler_ImagesSupport.md
+++ b/docs/tutorials/word/DocumentAssembler_ImagesSupport.md
@@ -72,6 +72,6 @@ Cheryl.]]></Description>
 
 ## Further Reading
 
-If you are interested in using the Image functionality in DocumentAssembler then your best bet is to look at `DocumentAssemblerTests.cs` and particularly the data files which can be found in the repository under `Test Files/DA`.
+If you are interested in using the Image functionality in DocumentAssembler then your best bet is to look at `DocumentAssemblerTests.cs` and particularly the data files which can be found in the repository under `TestFiles/DA`.
 
 Changes merged in: [#31](https://github.com/sergey-tihon/Clippit/pull/31)

--- a/docs/tutorials/word/DocumentAssembler_ImagesSupport.md
+++ b/docs/tutorials/word/DocumentAssembler_ImagesSupport.md
@@ -1,8 +1,11 @@
 ---
 uid: Tutorial.Word.DocumentAssembler.ImagesSupport
 ---
+# Images Support
 
-# Key highlights from [#31](https://github.com/sergey-tihon/Clippit/pull/31#issuecomment-874335292)
+Namespace: `Clippit.Word`
+
+Key highlights from [#31](https://github.com/sergey-tihon/Clippit/pull/31#issuecomment-874335292).
 
 ## Introduction
 

--- a/docs/tutorials/word/DocumentAssembler_InlineHtmlSupport.md
+++ b/docs/tutorials/word/DocumentAssembler_InlineHtmlSupport.md
@@ -1,8 +1,9 @@
 ---
 uid: Tutorial.Word.DocumentAssembler.InlineHtmlSupport
 ---
-
 # Inline HTML Support
+
+Namespace: `Clippit.Word`
 
 ## Introduction
 
@@ -31,7 +32,7 @@ Then Document Assembler would render this in Word as:
 
 ## Supported HTML tags
 
-Currently the following HTMl tags are supported.
+Currently the following HTML tags are supported.
 
 ### Block Tags
 
@@ -55,7 +56,7 @@ Inline HTML formatting is supported by default, you do not need to change your `
 
 ## Future Developments
 
-Inline HTML support is in it's infancy but it would make sense to add support for:
+Inline HTML support is in its infancy but it would make sense to add support for:
 
 * Ordered lists <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol" target="_blank">`ol`</a>
 * Unordered lists <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul" target="_blank">`ul`</a>

--- a/docs/tutorials/word/DocumentBuilder_CustomISource.md
+++ b/docs/tutorials/word/DocumentBuilder_CustomISource.md
@@ -1,125 +1,86 @@
 ---
 uid: Tutorial.Word.DocumentBuilder.ISource
 ---
-# Custom ISource implementation
+# Custom ISource Implementation
 
 Namespace: `Clippit.Word`
 
-`ISource` abstractions allow to use `DocumentBuild` with custom content selectors.
+The `ISource` interface allows using `DocumentBuilder` with custom content selectors.
+Implement this interface to define your own logic for selecting which elements from a
+source document should be included in the built document.
 
 ```csharp
-    public interface ISource : ICloneable
-    {
-        WmlDocument WmlDocument { get; set; }
+public interface ISource : ICloneable
+{
+    WmlDocument WmlDocument { get; set; }
+    bool KeepSections { get; set; }
+    bool DiscardHeadersAndFootersInKeptSections { get; set; }
+    string InsertId { get; set; }
 
-        bool KeepSections { get; set; }
-        public bool DiscardHeadersAndFootersInKeptSections { get; set; }
-
-        string InsertId { get; set; }
-
-        IEnumerable<XElement> GetElements(WordprocessingDocument document);
-    }
+    IEnumerable<XElement> GetElements(WordprocessingDocument document);
+}
 ```
 
-### RecursiveTableCellSource
+The `GetElements` method is called by `DocumentBuilder` to retrieve the content elements
+from the source document. Your implementation controls which elements are returned.
 
-Allow to reference tables inside tables
+## RecursiveTableCellSource
+
+`RecursiveTableCellSource` is an example custom `ISource` implementation that allows
+referencing content inside nested tables (tables within tables).
+
+### TableCellReference
+
+Each `TableCellReference` specifies one level of table nesting:
 
 ```csharp
-    [Serializable]
-    public class TableCellReference
+public class TableCellReference
+{
+    public int TableElementIndex { get; set; }  // Index of table in current context
+    public int RowIndex { get; set; }           // Row within the table
+    public int CellIndex { get; set; }          // Cell within the row
+}
+```
+
+### RecursiveTableCellSource Class
+
+```csharp
+public class RecursiveTableCellSource : ISource
+{
+    public WmlDocument WmlDocument { get; set; }
+    public bool KeepSections { get; set; }
+    public bool DiscardHeadersAndFootersInKeptSections { get; set; }
+    public string InsertId { get; set; }
+
+    // Navigation path through nested tables
+    public List<TableCellReference> TableCellReferences { get; set; }
+
+    // Content range within the final cell
+    public int Start { get; set; }
+    public int Count { get; set; }
+}
+```
+
+### RecursiveTableCellSource Sample
+
+```csharp
+var document = new WmlDocument("nested-tables.docx");
+
+// Navigate to: body -> table[0] -> row[1] -> cell[2] -> table[0] -> row[0] -> cell[1]
+// Then extract 3 elements starting from element 0
+var source = new RecursiveTableCellSource
+{
+    WmlDocument = document,
+    TableCellReferences = new List<TableCellReference>
     {
-        public int TableElementIndex { get; set; }
+        new() { TableElementIndex = 0, RowIndex = 1, CellIndex = 2 },  // Outer table
+        new() { TableElementIndex = 0, RowIndex = 0, CellIndex = 1 }   // Inner table
+    },
+    Start = 0,
+    Count = 3
+};
 
-        public int RowIndex { get; set; }
-
-        public int CellIndex { get; set; }
-    }
-
-    [Serializable]
-    public class RecursiveTableCellSource : ISource
-    {
-        public WmlDocument WmlDocument
-        {
-            get => _wmlDocument;
-            set => _wmlDocument = value;
-        }
-
-        [NonSerialized] private WmlDocument _wmlDocument;
-
-
-        public bool KeepSections { get; set; }
-        public bool DiscardHeadersAndFootersInKeptSections { get; set; }
-
-        public string InsertId { get; set; }
-
-
-        public List<TableCellReference> TableCellReferences { get; set; }
-
-        public int Start { get; set; }
-
-        public int Count { get; set; }
-
-
-        public IEnumerable<XElement> GetElements(WordprocessingDocument document)
-        {
-            var body = document.MainDocumentPart.GetXDocument().Root?.Element(W.body);
-            if (body is null)
-            {
-                throw new DocumentBuilderException(
-                    "Unsupported document - contains no body element in the correct namespace");
-            }
-
-            var elements = body.Elements();
-            foreach (var cellRef in TableCellReferences)
-            {
-                var table = elements.Skip(cellRef.TableElementIndex).FirstOrDefault();
-                if (table is null || table.Name != W.tbl)
-                {
-                    throw new DocumentBuilderException(
-                        $"Invalid {nameof(RecursiveTableCellSource)} - element {cellRef.TableElementIndex} is '{table?.Name}' but expected {W.tbl}");
-                }
-
-                var row = table.Elements(W.tr).Skip(cellRef.RowIndex).FirstOrDefault();
-                if (row is null)
-                {
-                    throw new DocumentBuilderException(
-                        $"Invalid {nameof(RecursiveTableCellSource)} - row {cellRef.RowIndex} does not exist");
-                }
-
-                var cell = row.Elements(W.tc).Skip(cellRef.CellIndex).FirstOrDefault();
-                if (cell is null)
-                {
-                    throw new DocumentBuilderException(
-                        $"Invalid {nameof(RecursiveTableCellSource)} - cell {cellRef.CellIndex} in the row {cellRef.RowIndex} does not exist");
-                }
-
-                elements = cell.Elements();
-            }
-
-            return elements
-                .Skip(Start)
-                .Take(Count)
-                .ToList();
-        }
-
-        public object Clone() =>
-            new RecursiveTableCellSource
-            {
-                WmlDocument = WmlDocument,
-                KeepSections = KeepSections,
-                DiscardHeadersAndFootersInKeptSections = DiscardHeadersAndFootersInKeptSections,
-                InsertId = InsertId,
-                TableCellReferences =
-                    TableCellReferences.Select(x =>
-                        new TableCellReference
-                        {
-                            TableElementIndex = x.TableElementIndex,
-                            RowIndex = x.RowIndex,
-                            CellIndex = x.CellIndex,
-                        }).ToList(),
-                Start = Start,
-                Count = Count
-            };
-    }
+var sources = new List<ISource> { source };
+var result = DocumentBuilder.BuildDocument(sources);
+result.SaveAs("extracted-content.docx");
 ```

--- a/docs/tutorials/word/DocumentBuilder_TableCellSource.md
+++ b/docs/tutorials/word/DocumentBuilder_TableCellSource.md
@@ -5,9 +5,40 @@ uid: Tutorial.Word.DocumentBuilder.TableCellSource
 
 Namespace: `Clippit.Word`
 
-`TableCellSource` allow to reference content of table cells.
+`TableCellSource` allows extracting content from a specific table cell and including it
+in the document being built.
 
-### Document Builder sample
+```csharp
+public class TableCellSource : ISource
+{
+    public TableCellSource() {...}
+    public TableCellSource(WmlDocument source) {...}
+
+    public WmlDocument WmlDocument { get; set; }
+    public bool KeepSections { get; set; }
+    public bool DiscardHeadersAndFootersInKeptSections { get; set; }
+    public string InsertId { get; set; }
+
+    // Table cell location
+    public int TableElementIndex { get; set; }
+    public int RowIndex { get; set; }
+    public int CellIndex { get; set; }
+
+    // Content range within the cell
+    public int CellContentStart { get; set; }
+    public int CellContentCount { get; set; }
+}
+```
+
+| Property | Description |
+|---|---|
+| `TableElementIndex` | Zero-based index of the table element in the document body |
+| `RowIndex` | Zero-based index of the row within the table |
+| `CellIndex` | Zero-based index of the cell within the row |
+| `CellContentStart` | Zero-based index of the first element to extract from the cell |
+| `CellContentCount` | Number of elements to extract from the cell |
+
+### DocumentBuilder Sample
 
 ```csharp {highlight:[12]}
     var document = new WmlDocument(sourceFilePath);

--- a/docs/tutorials/word/HtmlToWmlConverter.md
+++ b/docs/tutorials/word/HtmlToWmlConverter.md
@@ -1,0 +1,85 @@
+---
+uid: Tutorial.Word.HtmlToWmlConverter
+---
+# Convert HTML to Word
+
+Namespace: `Clippit.Html`
+
+Convert an XHTML document to a Word document, with configurable CSS cascading and page layout settings.
+
+```csharp
+public class HtmlToWmlConverter {
+    public static WmlDocument ConvertHtmlToWml(
+        string defaultCss, string authorCss, string userCss,
+        XElement xhtml, HtmlToWmlConverterSettings settings)
+    {...}
+
+    public static WmlDocument ConvertHtmlToWml(
+        string defaultCss, string authorCss, string userCss,
+        XElement xhtml, HtmlToWmlConverterSettings settings,
+        WmlDocument emptyDocument, string annotatedHtmlDumpFileName)
+    {...}
+
+    public static HtmlToWmlConverterSettings GetDefaultSettings()
+    {...}
+
+    public static string CleanUpCss(string css)
+    {...}
+}
+```
+
+The converter accepts XHTML as an `XElement` and produces a `WmlDocument`. CSS is applied in three
+layers following the CSS cascade: default (browser-like defaults), author (document styles), and
+user (overrides). The `GetDefaultSettings()` method returns a pre-configured
+`HtmlToWmlConverterSettings` with sensible page layout defaults.
+
+### HtmlToWmlConverterSettings
+
+| Field | Type | Description |
+|---|---|---|
+| `MajorLatinFont` | `string` | Major (heading) Latin font |
+| `MinorLatinFont` | `string` | Minor (body) Latin font |
+| `DefaultFontSize` | `double` | Default font size |
+| `DefaultSpacingElement` | `XElement` | Default paragraph spacing |
+| `DefaultSpacingElementForParagraphsInTables` | `XElement` | Default spacing in tables |
+| `SectPr` | `XElement` | Section properties (page size, margins) |
+| `DefaultBlockContentMargin` | `string` | Default margin for block content |
+| `BaseUriForImages` | `string` | Base URI for resolving image paths |
+
+The settings also expose read-only properties derived from `SectPr`:
+`PageWidthTwips`, `PageMarginLeftTwips`, `PageMarginRightTwips`,
+`PageWidthEmus`, `PageMarginLeftEmus`, `PageMarginRightEmus`.
+
+### Static Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `EmptyDocument` | `WmlDocument` | A minimal empty Word document used as a template |
+
+### HtmlToWmlConverter Sample
+
+```csharp
+var settings = HtmlToWmlConverter.GetDefaultSettings();
+settings.BaseUriForImages = "/images/";
+
+var defaultCss = File.ReadAllText("default.css");
+var authorCss = File.ReadAllText("styles.css");
+var userCss = "";
+
+var xhtml = XElement.Parse(@"
+<html xmlns='http://www.w3.org/1999/xhtml'>
+<head><title>Sample</title></head>
+<body>
+    <h1>Hello World</h1>
+    <p>This is a <strong>sample</strong> document converted from HTML.</p>
+    <table>
+        <tr><td>Cell 1</td><td>Cell 2</td></tr>
+        <tr><td>Cell 3</td><td>Cell 4</td></tr>
+    </table>
+</body>
+</html>");
+
+var doc = HtmlToWmlConverter.ConvertHtmlToWml(
+    defaultCss, authorCss, userCss, xhtml, settings);
+doc.SaveAs("output.docx");
+```

--- a/docs/tutorials/word/MarkupSimplifier.md
+++ b/docs/tutorials/word/MarkupSimplifier.md
@@ -1,0 +1,101 @@
+---
+uid: Tutorial.Word.MarkupSimplifier
+---
+# Simplify Markup
+
+Namespace: `Clippit.Word`
+
+Strip unnecessary markup from Word documents to simplify the underlying XML structure.
+
+```csharp
+public static class MarkupSimplifier {
+    public static WmlDocument SimplifyMarkup(
+        WmlDocument doc, SimplifyMarkupSettings settings)
+    {...}
+
+    public static void SimplifyMarkup(
+        WordprocessingDocument doc, SimplifyMarkupSettings settings)
+    {...}
+}
+```
+
+`MarkupSimplifier` removes various categories of markup that are often unnecessary for
+document processing, comparison, or conversion. Each category is controlled by a flag
+in `SimplifyMarkupSettings`.
+
+An instance method is also available directly on `WmlDocument`:
+
+```csharp
+var simplified = wmlDoc.SimplifyMarkup(settings);
+```
+
+### SimplifyMarkupSettings
+
+All fields are `bool` and default to `false`.
+
+| Field | Description |
+|---|---|
+| `AcceptRevisions` | Accept all tracked revisions before simplifying |
+| `NormalizeXml` | Normalize the XML structure |
+| `RemoveBookmarks` | Remove bookmark start/end elements |
+| `RemoveComments` | Remove comments and comment references |
+| `RemoveContentControls` | Remove structured document tags (content controls) |
+| `RemoveEndAndFootNotes` | Remove endnote and footnote references and content |
+| `RemoveFieldCodes` | Remove field codes, keeping field results |
+| `RemoveGoBackBookmark` | Remove the `_GoBack` bookmark |
+| `RemoveHyperlinks` | Remove hyperlink wrappers |
+| `RemoveLastRenderedPageBreak` | Remove `lastRenderedPageBreak` elements |
+| `RemoveMarkupForDocumentComparison` | Remove markup that interferes with document comparison (implies `RemoveRsidInfo`) |
+| `RemovePermissions` | Remove permission start/end elements |
+| `RemoveProof` | Remove proofing markup (spell check, grammar) |
+| `RemoveRsidInfo` | Remove revision save ID attributes |
+| `RemoveSmartTags` | Remove smart tag elements |
+| `RemoveSoftHyphens` | Remove soft hyphen characters |
+| `RemoveWebHidden` | Remove web-hidden paragraph marks |
+| `ReplaceTabsWithSpaces` | Replace tab characters with spaces |
+
+### Additional Methods
+
+| Method | Description |
+|---|---|
+| `MergeAdjacentSuperfluousRuns(XElement)` | Merge adjacent runs with identical formatting |
+| `TransformElementToSingleCharacterRuns(XElement)` | Split runs so each contains a single character |
+| `TransformPartToSingleCharacterRuns(OpenXmlPart)` | Apply single-character run transform to a part |
+| `TransformToSingleCharacterRuns(WordprocessingDocument)` | Apply single-character run transform to entire document |
+
+### SimplifyMarkup Sample
+
+```csharp
+var wmlDoc = new WmlDocument("input.docx");
+
+var settings = new SimplifyMarkupSettings
+{
+    RemoveComments = true,
+    RemoveRsidInfo = true,
+    RemoveProof = true,
+    RemoveBookmarks = true,
+    RemoveGoBackBookmark = true,
+    RemoveSoftHyphens = true,
+    RemoveLastRenderedPageBreak = true,
+    RemoveContentControls = true,
+    RemoveSmartTags = true
+};
+
+var simplified = wmlDoc.SimplifyMarkup(settings);
+simplified.SaveAs("simplified.docx");
+```
+
+### Prepare for Comparison Sample
+
+```csharp
+var settings = new SimplifyMarkupSettings
+{
+    RemoveMarkupForDocumentComparison = true,
+    AcceptRevisions = true
+};
+
+var doc1 = new WmlDocument("doc1.docx").SimplifyMarkup(settings);
+var doc2 = new WmlDocument("doc2.docx").SimplifyMarkup(settings);
+
+// Documents are now ready for structural comparison
+```

--- a/docs/tutorials/word/RevisionProcessor.md
+++ b/docs/tutorials/word/RevisionProcessor.md
@@ -1,0 +1,82 @@
+---
+uid: Tutorial.Word.RevisionProcessor
+---
+# Process Revisions
+
+Namespace: `Clippit.Word`
+
+Accept or reject tracked revisions in Word documents programmatically.
+
+```csharp
+public class RevisionProcessor {
+    public static WmlDocument AcceptRevisions(WmlDocument document)
+    {...}
+    public static void AcceptRevisions(WordprocessingDocument doc)
+    {...}
+
+    public static WmlDocument RejectRevisions(WmlDocument document)
+    {...}
+    public static void RejectRevisions(WordprocessingDocument doc)
+    {...}
+
+    public static void AcceptRevisionsForPart(OpenXmlPart part)
+    {...}
+    public static XElement AcceptRevisionsForElement(XElement element)
+    {...}
+
+    public static bool HasTrackedRevisions(WmlDocument document)
+    {...}
+    public static bool HasTrackedRevisions(WordprocessingDocument doc)
+    {...}
+    public static bool PartHasTrackedRevisions(OpenXmlPart part)
+    {...}
+}
+```
+
+`RevisionProcessor` handles both accepting and rejecting tracked revisions across
+all document parts (main document, headers, footers, footnotes, endnotes, and styles).
+
+#### Key Features
+
+- **Accept revisions** -- applies all insertions and removes all deletions, producing a clean document
+- **Reject revisions** -- reverses all insertions and restores all deletions, returning to the original state
+- **Part-level control** -- accept revisions for individual parts or XML elements
+- **Detection** -- check whether a document or part contains tracked revisions
+
+An instance method is also available directly on `WmlDocument`:
+
+```csharp
+var cleanDoc = wmlDoc.AcceptRevisions();
+```
+
+### AcceptRevisions Sample
+
+```csharp
+var wmlDoc = new WmlDocument("document_with_revisions.docx");
+
+if (wmlDoc.HasTrackedRevisions())
+{
+    var accepted = RevisionProcessor.AcceptRevisions(wmlDoc);
+    accepted.SaveAs("document_clean.docx");
+}
+```
+
+### RejectRevisions Sample
+
+```csharp
+var wmlDoc = new WmlDocument("document_with_revisions.docx");
+
+var rejected = RevisionProcessor.RejectRevisions(wmlDoc);
+rejected.SaveAs("document_original.docx");
+```
+
+### AcceptRevisionsForPart Sample
+
+```csharp
+using var doc = WordprocessingDocument.Open("input.docx", true);
+
+// Accept revisions only in the main document part
+RevisionProcessor.AcceptRevisionsForPart(doc.MainDocumentPart);
+
+doc.Save();
+```

--- a/docs/tutorials/word/RevisionProcessor.md
+++ b/docs/tutorials/word/RevisionProcessor.md
@@ -43,10 +43,10 @@ all document parts (main document, headers, footers, footnotes, endnotes, and st
 - **Part-level control** -- accept revisions for individual parts or XML elements
 - **Detection** -- check whether a document or part contains tracked revisions
 
-An instance method is also available directly on `WmlDocument`:
+You can call the static API on `RevisionProcessor`:
 
 ```csharp
-var cleanDoc = wmlDoc.AcceptRevisions();
+var cleanDoc = RevisionProcessor.AcceptRevisions(wmlDoc);
 ```
 
 ### AcceptRevisions Sample
@@ -54,7 +54,7 @@ var cleanDoc = wmlDoc.AcceptRevisions();
 ```csharp
 var wmlDoc = new WmlDocument("document_with_revisions.docx");
 
-if (wmlDoc.HasTrackedRevisions())
+if (RevisionProcessor.HasTrackedRevisions(wmlDoc))
 {
     var accepted = RevisionProcessor.AcceptRevisions(wmlDoc);
     accepted.SaveAs("document_clean.docx");

--- a/docs/tutorials/word/WmlComparer.md
+++ b/docs/tutorials/word/WmlComparer.md
@@ -1,0 +1,114 @@
+---
+uid: Tutorial.Word.WmlComparer
+---
+# Compare Documents
+
+Namespace: `Clippit`
+
+Compare two Word documents and produce a result document with tracked revisions showing the differences.
+Consolidate multiple revised documents against an original, or extract a list of revisions from a comparison result.
+
+```csharp
+public static class WmlComparer {
+    public static WmlDocument Compare(
+        WmlDocument source1, WmlDocument source2, WmlComparerSettings settings)
+    {...}
+
+    public static WmlDocument Consolidate(
+        WmlDocument original,
+        List<WmlRevisedDocumentInfo> revisedDocumentInfoList,
+        WmlComparerSettings settings)
+    {...}
+
+    public static List<WmlComparerRevision> GetRevisions(
+        WmlDocument source, WmlComparerSettings settings)
+    {...}
+}
+```
+
+### Compare
+
+Compares two Word documents and returns a new document containing tracked revisions (insertions and deletions)
+that represent the differences between `source1` and `source2`. The comparison operates at the word level
+by default, using `WordSeparators` from `WmlComparerSettings` to split text into tokens.
+
+### Consolidate
+
+Merges multiple revised versions of a document against a common original. Each revised document is provided
+with a revisor name and color via `WmlRevisedDocumentInfo`. The result contains tracked revisions from all
+revisors. By default, revisions are wrapped in a comparison table (controlled by `WmlComparerConsolidateSettings.ConsolidateWithTable`).
+
+### GetRevisions
+
+Extracts a flat list of `WmlComparerRevision` objects from a document that contains tracked revisions
+(typically the output of `Compare` or `Consolidate`). Each revision includes the revision type
+(`Inserted` or `Deleted`), text content, author, and date.
+
+### WmlComparerSettings
+
+| Property | Type | Default |
+|---|---|---|
+| `WordSeparators` | `char[]` | `[' ', '-', ')', '(', ';', ',']` |
+| `AuthorForRevisions` | `string` | `"Open-Xml-PowerTools"` |
+| `DateTimeForRevisions` | `string` | `DateTime.Now.ToString("o")` |
+| `DetailThreshold` | `double` | `0.15` |
+| `CaseInsensitive` | `bool` | `false` |
+| `CultureInfo` | `CultureInfo` | `null` |
+| `LogCallback` | `Action<string>` | `null` |
+| `StartingIdForFootnotesEndnotes` | `int` | `1` |
+| `DebugTempFileDi` | `DirectoryInfo` | `null` |
+
+### Compare Sample
+
+```csharp
+var source1 = new WmlDocument("Original.docx");
+var source2 = new WmlDocument("Revised.docx");
+
+var settings = new WmlComparerSettings
+{
+    AuthorForRevisions = "Comparison Tool",
+    DetailThreshold = 0.15
+};
+
+var comparedDoc = WmlComparer.Compare(source1, source2, settings);
+comparedDoc.SaveAs("Comparison.docx");
+```
+
+### Consolidate Sample
+
+```csharp
+var original = new WmlDocument("Original.docx");
+
+var revisedDocs = new List<WmlRevisedDocumentInfo>
+{
+    new()
+    {
+        RevisedDocument = new WmlDocument("Revised_Alice.docx"),
+        Revisor = "Alice",
+        Color = Color.LightBlue
+    },
+    new()
+    {
+        RevisedDocument = new WmlDocument("Revised_Bob.docx"),
+        Revisor = "Bob",
+        Color = Color.LightGreen
+    }
+};
+
+var settings = new WmlComparerSettings();
+
+var consolidated = WmlComparer.Consolidate(original, revisedDocs, settings);
+consolidated.SaveAs("Consolidated.docx");
+```
+
+### GetRevisions Sample
+
+```csharp
+var comparedDoc = WmlComparer.Compare(source1, source2, settings);
+
+var revisions = WmlComparer.GetRevisions(comparedDoc, settings);
+foreach (var rev in revisions)
+{
+    Console.WriteLine($"{rev.RevisionType}: \"{rev.Text}\" by {rev.Author} on {rev.Date}");
+}
+```

--- a/docs/tutorials/word/WmlToHtmlConverter.md
+++ b/docs/tutorials/word/WmlToHtmlConverter.md
@@ -1,0 +1,87 @@
+---
+uid: Tutorial.Word.WmlToHtmlConverter
+---
+# Convert Word to HTML
+
+Namespace: `Clippit.Word`
+
+Convert a Word document to an HTML `XElement`, with configurable CSS generation and image handling.
+
+```csharp
+public static class WmlToHtmlConverter {
+    public static XElement ConvertToHtml(
+        WmlDocument doc, WmlToHtmlConverterSettings htmlConverterSettings)
+    {...}
+
+    public static XElement ConvertToHtml(
+        WordprocessingDocument wordDoc, WmlToHtmlConverterSettings htmlConverterSettings)
+    {...}
+}
+```
+
+The converter produces a complete HTML document as an `XElement` (XHTML). It generates CSS classes
+for paragraph and character styles, handles numbering/lists, and processes images through a
+configurable `ImageHandler` callback.
+
+An extension method is also available directly on `WmlDocument`:
+
+```csharp
+WmlDocument doc = new WmlDocument("input.docx");
+XElement html = doc.ConvertToHtml(settings);
+```
+
+### WmlToHtmlConverterSettings
+
+| Field | Type | Default |
+|---|---|---|
+| `PageTitle` | `string` | `""` |
+| `CssClassPrefix` | `string` | `"pt-"` |
+| `FabricateCssClasses` | `bool` | `true` |
+| `GeneralCss` | `string` | `"span { white-space: pre-wrap; }"` |
+| `AdditionalCss` | `string` | `""` |
+| `RestrictToSupportedLanguages` | `bool` | `false` |
+| `RestrictToSupportedNumberingFormats` | `bool` | `false` |
+| `ImageHandler` | `Func<ImageInfo, XElement>` | `null` |
+
+### ImageInfo
+
+The `ImageHandler` callback receives an `ImageInfo` object for each image in the document:
+
+| Field | Type | Description |
+|---|---|---|
+| `Image` | `SixLabors.ImageSharp.Image` | The decoded image |
+| `ImgStyleAttribute` | `XAttribute` | The computed `style` attribute (width/height) |
+| `ContentType` | `string` | The image MIME type |
+| `DrawingElement` | `XElement` | The source OpenXml drawing element |
+| `AltText` | `string` | Alternative text for the image |
+
+### WmlToHtmlConverter Sample
+
+```csharp
+var doc = new WmlDocument("input.docx");
+
+var settings = new WmlToHtmlConverterSettings
+{
+    PageTitle = "My Document",
+    CssClassPrefix = "doc-",
+    FabricateCssClasses = true,
+    AdditionalCss = "body { font-family: Calibri, sans-serif; }",
+    ImageHandler = imageInfo =>
+    {
+        // Convert images to inline base64 data URIs
+        using var stream = new MemoryStream();
+        imageInfo.Image.SaveAsPng(stream);
+        var base64 = Convert.ToBase64String(stream.ToArray());
+        var imgElement = new XElement(
+            Xhtml.img,
+            imageInfo.ImgStyleAttribute,
+            new XAttribute("src", $"data:image/png;base64,{base64}"),
+            new XAttribute("alt", imageInfo.AltText ?? "")
+        );
+        return imgElement;
+    }
+};
+
+var html = WmlToHtmlConverter.ConvertToHtml(doc, settings);
+File.WriteAllText("output.html", html.ToString());
+```

--- a/docs/tutorials/word/toc.yml
+++ b/docs/tutorials/word/toc.yml
@@ -1,9 +1,3 @@
-- name: DocumentBuilder
-  items:
-  - name: Custom ISource
-    href: DocumentBuilder_CustomISource.md
-  - name: TableCellSource
-    href: DocumentBuilder_TableCellSource.md
 - name: DocumentAssembler
   items:
   - name: Images Support
@@ -12,3 +6,19 @@
     href: DocumentAssembler_InlineHtmlSupport.md
   - name: Processing Documents and Document Templates
     href: DocumentAssembler_DocumentTemplates.md
+- name: DocumentBuilder
+  items:
+  - name: Custom ISource
+    href: DocumentBuilder_CustomISource.md
+  - name: TableCellSource
+    href: DocumentBuilder_TableCellSource.md
+- name: HtmlToWmlConverter
+  href: HtmlToWmlConverter.md
+- name: MarkupSimplifier
+  href: MarkupSimplifier.md
+- name: RevisionProcessor
+  href: RevisionProcessor.md
+- name: WmlComparer
+  href: WmlComparer.md
+- name: WmlToHtmlConverter
+  href: WmlToHtmlConverter.md


### PR DESCRIPTION
## Summary

This PR significantly improves the Clippit documentation:

- **9 new tutorial pages** covering previously undocumented features:
  - Word: WmlComparer, WmlToHtmlConverter, HtmlToWmlConverter, RevisionProcessor, MarkupSimplifier
  - PowerPoint: Fluent API for PresentationBuilder
  - Excel: SmlDataRetriever
  - Common: OpenXmlRegex, MetricsGetter

- **Modernized landing page** (`docs/index.md`):
  - Clear value proposition instead of "fork of" framing
  - Getting Started section with install command and code sample
  - Feature catalog with tables linking to all 17 tutorials
  - Fixed broken xref links (Word → PowerPoint namespace)
  - Removed stale external links to ericwhite.com
  - Added Compatibility and Questions sections

- **Existing docs improvements**:
  - Fixed uid namespaces in BuildPresentation*.md
  - Added missing `Namespace:` lines to DocumentAssembler pages
  - Added Cell Builder section to SpreadsheetWriter.md
  - Fixed typos and broken XML tags

- **Build/CI fixes**:
  - Fixed `&&` → `and` in XML doc comments (InvalidXmlComment warnings)
  - Added CHANGELOG copy step to build.fsx and CI workflow