### PR TITLE
[Clippy] eng: update SDK floor to 10.0.100, bump DocumentFormat.OpenXml 3.5.1 and TUnit 1.20.0

### DIFF
--- a/Clippit.Tests/Clippit.Tests.csproj
+++ b/Clippit.Tests/Clippit.Tests.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="TUnit" Version="1.19.57" />
+    <PackageReference Include="TUnit" Version="1.20.0" />
   </ItemGroup>
 </Project>

--- a/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Deduplication.cs
+++ b/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Deduplication.cs
@@ -28,11 +28,13 @@ internal partial class FluentPresentationBuilder
         // TODO: enumerate all images, media, master and layouts
         _slideSize = presentation.Presentation.SlideSize;
 
-        var existingSlideIds = presentation
-            .GetXDocument()
-            ?.Root?.Descendants(P.sldId)
-            .Select(f => (uint)f.Attribute(NoNamespace.id))
-            .ToList() ?? [];
+        var existingSlideIds =
+            presentation
+                .GetXDocument()
+                ?.Root?.Descendants(P.sldId)
+                .Select(f => (uint)f.Attribute(NoNamespace.id))
+                .ToList()
+            ?? [];
         _nextSlideId = existingSlideIds.Count > 0 ? existingSlideIds.Max() + 1 : 256;
     }
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.4.1" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8" PrivateAssets="all" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.200",
+    "version": "10.0.100",
     "rollForward": "latestMinor"
   },
   "test": {


### PR DESCRIPTION
…3.5.1, TUnit 1.19.57→1.20.0

- global.json: lower SDK floor from 10.0.200 to 10.0.100 (rollForward: latestMinor keeps using the latest installed 10.0.x patch)
- Directory.Build.props: DocumentFormat.OpenXml 3.4.1 → 3.5.1
- Clippit.Tests.csproj: TUnit 1.19.57 → 1.20.0

All 1165 tests pass with the new package versions.