### PR TITLE
ci: add NuGet package cache to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
               uses: actions/setup-dotnet@v5
               with:
                   global-json-file: global.json
+                  cache: true
             - name: Build and Test
               run: dotnet fsi build.fsx -- -p build
             - name: Upload Artifacts
@@ -45,6 +46,7 @@ jobs:
               uses: actions/setup-dotnet@v5
               with:
                   global-json-file: global.json
+                  cache: true
             - name: Restore Tools
               run: dotnet tool restore
             - name: Restore


### PR DESCRIPTION
Enable actions/setup-dotnet's built-in NuGet cache (cache: true) for both the build matrix and generate-docs jobs. This caches restored NuGet packages between runs, reducing dotnet restore time on cache hits.