### PR TITLE
[Clippy] ci: add NuGet publish workflow triggered by version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,13 +20,11 @@ jobs:
                   global-json-file: global.json
             - name: Build and Pack
               run: ./build.sh
+              shell: bash
             - name: Publish to NuGet
               run: |
-                  dotnet nuget push bin/*.nupkg \
+                  dotnet nuget push bin/*.{nupkg,snupkg} \
                     --api-key ${{ secrets.NUGET_API_KEY }} \
                     --source https://api.nuget.org/v3/index.json \
                     --skip-duplicate
-                  dotnet nuget push bin/*.snupkg \
-                    --api-key ${{ secrets.NUGET_API_KEY }} \
-                    --source https://api.nuget.org/v3/index.json \
-                    --skip-duplicate
+              shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish NuGet Package
 on:
     push:
         tags:
-            - "v[0-9]+.[0-9]+.[0-9]+"
+            - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
     publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish NuGet Package
 on:
     push:
         tags:
-            - "v[0-9]*.[0-9]*.[0-9]*"
+            - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
     publish:
@@ -23,10 +23,14 @@ jobs:
               shell: bash
             - name: Publish to NuGet
               run: |
-                  for packagePattern in bin/*.nupkg bin/*.snupkg; do
-                      dotnet nuget push "$packagePattern" \
+                  dotnet nuget push bin/*.nupkg \
+                    --api-key ${{ secrets.NUGET_API_KEY }} \
+                    --source https://api.nuget.org/v3/index.json \
+                    --skip-duplicate
+                  if compgen -G "bin/*.snupkg" > /dev/null; then
+                      dotnet nuget push bin/*.snupkg \
                         --api-key ${{ secrets.NUGET_API_KEY }} \
                         --source https://api.nuget.org/v3/index.json \
                         --skip-duplicate
-                  done
+                  fi
               shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,10 @@ jobs:
               shell: bash
             - name: Publish to NuGet
               run: |
-                  dotnet nuget push bin/*.{nupkg,snupkg} \
-                    --api-key ${{ secrets.NUGET_API_KEY }} \
-                    --source https://api.nuget.org/v3/index.json \
-                    --skip-duplicate
+                  for packagePattern in "bin/*.nupkg" "bin/*.snupkg"; do
+                      dotnet nuget push $packagePattern \
+                        --api-key ${{ secrets.NUGET_API_KEY }} \
+                        --source https://api.nuget.org/v3/index.json \
+                        --skip-duplicate
+                  done
               shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   global-json-file: global.json
             - name: Build and Pack
-              run: bash ./build.sh
+              run: dotnet fsi build.fsx -- -p build
             - name: Publish to NuGet
               run: |
                   dotnet nuget push bin/*.nupkg \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
               shell: bash
             - name: Publish to NuGet
               run: |
-                  for packagePattern in "bin/*.nupkg" "bin/*.snupkg"; do
-                      dotnet nuget push $packagePattern \
+                  for packagePattern in bin/*.nupkg bin/*.snupkg; do
+                      dotnet nuget push "$packagePattern" \
                         --api-key ${{ secrets.NUGET_API_KEY }} \
                         --source https://api.nuget.org/v3/index.json \
                         --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish NuGet Package
 on:
     push:
         tags:
-            - "v[0-9]+.[0-9]+.[0-9]+"
+            - "v[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
     publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,15 @@ jobs:
               uses: actions/setup-dotnet@v5
               with:
                   global-json-file: global.json
-                  cache: true
             - name: Build and Pack
-              run: dotnet fsi build.fsx -- -p build
+              run: ./build.sh
             - name: Publish to NuGet
               run: |
                   dotnet nuget push bin/*.nupkg \
+                    --api-key ${{ secrets.NUGET_API_KEY }} \
+                    --source https://api.nuget.org/v3/index.json \
+                    --skip-duplicate
+                  dotnet nuget push bin/*.snupkg \
                     --api-key ${{ secrets.NUGET_API_KEY }} \
                     --source https://api.nuget.org/v3/index.json \
                     --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,18 +19,10 @@ jobs:
               with:
                   global-json-file: global.json
             - name: Build and Pack
-              run: ./build.sh
-              shell: bash
+              run: bash ./build.sh
             - name: Publish to NuGet
               run: |
                   dotnet nuget push bin/*.nupkg \
                     --api-key ${{ secrets.NUGET_API_KEY }} \
                     --source https://api.nuget.org/v3/index.json \
                     --skip-duplicate
-                  if compgen -G "bin/*.snupkg" > /dev/null; then
-                      dotnet nuget push bin/*.snupkg \
-                        --api-key ${{ secrets.NUGET_API_KEY }} \
-                        --source https://api.nuget.org/v3/index.json \
-                        --skip-duplicate
-                  fi
-              shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish NuGet Package
+
+on:
+    push:
+        tags:
+            - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+            - name: Setup .NET SDK
+              uses: actions/setup-dotnet@v5
+              with:
+                  global-json-file: global.json
+                  cache: true
+            - name: Build and Pack
+              run: dotnet fsi build.fsx -- -p build
+            - name: Publish to NuGet
+              run: |
+                  dotnet nuget push bin/*.nupkg \
+                    --api-key ${{ secrets.NUGET_API_KEY }} \
+                    --source https://api.nuget.org/v3/index.json \
+                    --skip-duplicate


### PR DESCRIPTION
Adds a publish.yml workflow that automatically publishes the NuGet package
when a version tag (e.g. v3.4.0) is pushed. The workflow:

1. Runs the full build pipeline (dotnet fsi build.fsx -- -p build) which
   builds, tests, and packs the NuGet package with the version from CHANGELOG.md
2. Pushes the resulting .nupkg and .snupkg files to nuget.org

Prerequisites for the maintainer:
- Add a NUGET_API_KEY repository secret with a nuget.org API key that has
  publish rights for the 'Clippit' package

To release: create and push a tag matching the CHANGELOG version, e.g.
  git tag v3.4.0 && git push origin v3.4.0

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
