### PR TITLE
Fix PowerPoint relationship copying edge cases

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.2] - 2026-06-02
+
+Patch release for the next CLI package publish.
+
 ## [0.1.1] - 2026-06-01
 
 Patch release focused on NativeAOT packaging/runtime stability.

--- a/Clippit.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.Fluent.cs
+++ b/Clippit.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.Fluent.cs
@@ -244,6 +244,86 @@ public partial class PresentationBuilderSlidePublishingTests
         await Assert.That(destStream.Length).IsGreaterThan(0);
     }
 
+    /// <summary>
+    /// Regression test: a slide whose p:custData element references an empty (zero-byte)
+    /// CustomXmlPart should be copied without error, and the empty part must not appear
+    /// in the output (it has no root element and causes a PowerPoint repair dialog).
+    /// </summary>
+    [Test]
+    public async Task AddSlidePart_WithEmptyCustDataPart_SkipsEmptyPartAndDoesNotThrow()
+    {
+        var sourcePath = Path.Combine(SourceDirectory, "BRK3066.pptx");
+        var openSettings = new OpenSettings { AutoSave = false };
+
+        using var srcMemory = new MemoryStream();
+        await using (var fs = File.OpenRead(sourcePath))
+            await fs.CopyToAsync(srcMemory);
+        srcMemory.Position = 0;
+
+        using var srcDoc = PresentationDocument.Open(srcMemory, true, openSettings);
+        ArgumentNullException.ThrowIfNull(srcDoc.PresentationPart);
+
+        var firstSlideId = PresentationBuilderTools.GetSlideIdsInOrder(srcDoc).First();
+        var srcSlidePart = (SlidePart)srcDoc.PresentationPart.GetPartById(firstSlideId);
+
+        // Attach an empty CustomXmlPart (zero bytes, no root element) to the slide.
+        var emptyXmlPart = srcSlidePart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
+        // deliberately leave the stream empty (no PutXDocument call)
+
+        var propsPart = emptyXmlPart.AddNewPart<CustomXmlPropertiesPart>();
+        propsPart.PutXDocument(
+            new XDocument(
+                new XElement(
+                    XName.Get("datastoreItem", "http://schemas.openxmlformats.org/officeDocument/2006/customXml"),
+                    new XAttribute(
+                        XName.Get("itemID", "http://schemas.openxmlformats.org/officeDocument/2006/customXml"),
+                        "{7D2CF446-7740-064C-89BA-4FB9111814D7}"
+                    )
+                )
+            )
+        );
+
+        XNamespace pns = "http://schemas.openxmlformats.org/presentationml/2006/main";
+        XNamespace rns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        var custDataRelId = srcSlidePart.GetIdOfPart(emptyXmlPart);
+        var slideXDoc = srcSlidePart.GetXDocument();
+        slideXDoc.Root?.Add(
+            new XElement(pns + "custDataLst", new XElement(pns + "custData", new XAttribute(rns + "id", custDataRelId)))
+        );
+        srcSlidePart.PutXDocument(slideXDoc);
+
+        using var destStream = new MemoryStream();
+        // Should not throw
+        using (var destDoc = PresentationBuilder.NewDocument(destStream))
+        using (var builder = PresentationBuilder.Create(destDoc))
+        {
+            builder.AddSlidePart(srcSlidePart);
+        }
+
+        await Assert.That(destStream.Length).IsGreaterThan(0);
+
+        // The empty customXml part must not appear in the output package.
+        destStream.Position = 0;
+        using var archive = new System.IO.Compression.ZipArchive(destStream, System.IO.Compression.ZipArchiveMode.Read);
+        var customXmlEntries = archive
+            .Entries.Where(e =>
+                e.FullName.StartsWith("customXml/item", StringComparison.Ordinal)
+                && e.FullName.EndsWith(".xml", StringComparison.Ordinal)
+                && !e.FullName.Contains("Props", StringComparison.Ordinal)
+            )
+            .ToList();
+        await Assert.That(customXmlEntries).IsEmpty();
+
+        // The <p:custDataLst> element must also be pruned from the slide XML
+        // so no dangling relationship reference remains.
+        destStream.Position = 0;
+        using var doc = PresentationDocument.Open(destStream, false);
+        var slidePart = doc.PresentationPart!.SlideParts.First();
+        XNamespace pns2 = "http://schemas.openxmlformats.org/presentationml/2006/main";
+        var custDataLst = slidePart.GetXDocument().Root?.Element(pns2 + "custDataLst");
+        await Assert.That(custDataLst).IsNull();
+    }
+
     [Test]
     [MethodDataSource(typeof(PublishingTestData), nameof(PublishingTestData.Files))]
     public async Task MergeAllPowerPointBack(string sourcePath, CancellationToken cancellationToken)

--- a/Clippit.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.Fluent.cs
+++ b/Clippit.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.Fluent.cs
@@ -304,7 +304,11 @@ public partial class PresentationBuilderSlidePublishingTests
 
         // The empty customXml part must not appear in the output package.
         destStream.Position = 0;
-        using var archive = new System.IO.Compression.ZipArchive(destStream, System.IO.Compression.ZipArchiveMode.Read);
+        using var archive = new System.IO.Compression.ZipArchive(
+            destStream,
+            System.IO.Compression.ZipArchiveMode.Read,
+            leaveOpen: true
+        );
         var customXmlEntries = archive
             .Entries.Where(e =>
                 e.FullName.StartsWith("customXml/item", StringComparison.Ordinal)

--- a/Clippit.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.Fluent.cs
+++ b/Clippit.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.Fluent.cs
@@ -304,19 +304,23 @@ public partial class PresentationBuilderSlidePublishingTests
 
         // The empty customXml part must not appear in the output package.
         destStream.Position = 0;
-        using var archive = new System.IO.Compression.ZipArchive(
-            destStream,
-            System.IO.Compression.ZipArchiveMode.Read,
-            leaveOpen: true
-        );
-        var customXmlEntries = archive
-            .Entries.Where(e =>
-                e.FullName.StartsWith("customXml/item", StringComparison.Ordinal)
-                && e.FullName.EndsWith(".xml", StringComparison.Ordinal)
-                && !e.FullName.Contains("Props", StringComparison.Ordinal)
+        using (
+            var archive = new System.IO.Compression.ZipArchive(
+                destStream,
+                System.IO.Compression.ZipArchiveMode.Read,
+                leaveOpen: true
             )
-            .ToList();
-        await Assert.That(customXmlEntries).IsEmpty();
+        )
+        {
+            var customXmlEntries = archive
+                .Entries.Where(e =>
+                    e.FullName.StartsWith("customXml/item", StringComparison.Ordinal)
+                    && e.FullName.EndsWith(".xml", StringComparison.Ordinal)
+                    && !e.FullName.Contains("Props", StringComparison.Ordinal)
+                )
+                .ToList();
+            await Assert.That(customXmlEntries).IsEmpty();
+        }
 
         // The <p:custDataLst> element must also be pruned from the slide XML
         // so no dangling relationship reference remains.

--- a/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
+++ b/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
@@ -426,7 +426,7 @@ internal sealed partial class FluentPresentationBuilder
         //   - Duplicate-copy guards (HasRelationship / DataPartReferenceRelationships.Any)
         //     prevent double-processing if the same relId appears more than once in the tree.
         // Within each element type, document order is preserved just as in the original code.
-        foreach (var element in newContent.DescendantsAndSelf())
+        foreach (var element in newContent.DescendantsAndSelf().ToList())
         {
             var name = element.Name;
 
@@ -669,8 +669,30 @@ internal sealed partial class FluentPresentationBuilder
                 var oldPartIdPair9 = oldContentPart.Parts.FirstOrDefault(p => p.RelationshipId == relId);
                 if (oldPartIdPair9 != default)
                 {
+                    // Skip empty CustomXml parts: a zero-byte stream has no root element and
+                    // will make PowerPoint show a repair dialog when it opens the output file.
+                    // Such parts are occasionally produced by SharePoint/AI generators and carry
+                    // no meaningful content, so dropping them is safe.
+                    // Buffer into memory: lets us check length AND rewind regardless of
+                    // whether the underlying stream is seekable (DeflateStream from a
+                    // file-backed package is not seekable).
+                    using var srcStream = oldPartIdPair9.OpenXmlPart.GetStream();
+                    var buf = new MemoryStream();
+                    srcStream.CopyTo(buf);
+                    if (buf.Length == 0)
+                    {
+                        // Remove the referencing <p:custData> element and prune an empty
+                        // <p:custDataLst> parent so the slide XML doesn't keep a dangling relId.
+                        var parent = element.Parent;
+                        element.Remove();
+                        if (parent?.Name == P.custDataLst && !parent.HasElements)
+                            parent.Remove();
+                        continue;
+                    }
+
                     var newPart = _newDocument.PresentationPart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
-                    newPart.FeedDataFrom(oldPartIdPair9.OpenXmlPart);
+                    buf.Position = 0;
+                    newPart.FeedData(buf);
                     foreach (
                         var itemProps in oldPartIdPair9.OpenXmlPart.Parts.Where(p =>
                             p.OpenXmlPart.ContentType
@@ -786,7 +808,11 @@ internal sealed partial class FluentPresentationBuilder
             var temp = GetOrAddImageCopy(oldPart);
             if (temp.ImagePart is null)
             {
-                var contentType = oldPart?.ContentType;
+                // Normalize non-standard SVG MIME type produced by some generators.
+                // "image/svg" is not a registered MIME type; the correct type is "image/svg+xml".
+                // When both appear in the same package PowerPoint detects the inconsistency
+                // and shows a repair dialog, so we normalise here at copy time.
+                var contentType = oldPart?.ContentType == "image/svg" ? "image/svg+xml" : oldPart?.ContentType;
                 var targetExtension = contentType switch
                 {
                     "image/bmp" => ".bmp",

--- a/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
+++ b/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
@@ -417,7 +417,8 @@ internal sealed partial class FluentPresentationBuilder
         // Single pass over the entire element tree dispatches all relationship-copying work.
         // The previous implementation traversed DescendantsAndSelf() up to 16 separate times
         // (once per element-type group). A single dispatch loop reduces tree visits from O(16N)
-        // to O(N) and eliminates intermediate List<XElement> allocations.
+        // to O(N). The traversal is materialized once so p:custData pruning can safely remove
+        // nodes while the relationship-copying loop continues.
         //
         // Ordering note: elements are now visited in document order rather than per-type-group
         // order. This is safe because every copy helper is independent and idempotent:
@@ -677,7 +678,7 @@ internal sealed partial class FluentPresentationBuilder
                     // whether the underlying stream is seekable (DeflateStream from a
                     // file-backed package is not seekable).
                     using var srcStream = oldPartIdPair9.OpenXmlPart.GetStream();
-                    var buf = new MemoryStream();
+                    using var buf = new MemoryStream();
                     srcStream.CopyTo(buf);
                     if (buf.Length == 0)
                     {

--- a/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
+++ b/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
@@ -675,22 +675,20 @@ internal sealed partial class FluentPresentationBuilder
                     // Such parts are occasionally produced by SharePoint/AI generators and carry
                     // no meaningful content, so dropping them is safe.
                     CustomXmlPart newPart = null;
-                    var skipCustomXmlPart = false;
                     try
                     {
                         using var srcStream = oldPartIdPair9.OpenXmlPart.GetStream();
                         var firstByte = srcStream.ReadByte();
                         if (firstByte < 0)
                         {
-                            skipCustomXmlPart = true;
+                            PruneCustDataReference(element);
+                            continue;
                         }
-                        else
-                        {
-                            newPart = _newDocument.PresentationPart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
-                            using var dstStream = newPart.GetStream(FileMode.Create, FileAccess.Write);
-                            dstStream.WriteByte((byte)firstByte);
-                            srcStream.CopyTo(dstStream);
-                        }
+
+                        newPart = _newDocument.PresentationPart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
+                        using var dstStream = newPart.GetStream(FileMode.Create, FileAccess.Write);
+                        dstStream.WriteByte((byte)firstByte);
+                        srcStream.CopyTo(dstStream);
                     }
                     catch (InvalidDataException)
                     {
@@ -698,17 +696,8 @@ internal sealed partial class FluentPresentationBuilder
                         // CustomXml content as empty and drop its dangling p:custData reference.
                         if (newPart is not null)
                             _newDocument.PresentationPart.DeletePart(newPart);
-                        skipCustomXmlPart = true;
-                    }
 
-                    if (skipCustomXmlPart)
-                    {
-                        // Remove the referencing <p:custData> element and prune an empty
-                        // <p:custDataLst> parent so the slide XML doesn't keep a dangling relId.
-                        var parent = element.Parent;
-                        element.Remove();
-                        if (parent?.Name == P.custDataLst && !parent.HasElements)
-                            parent.Remove();
+                        PruneCustDataReference(element);
                         continue;
                     }
 
@@ -734,6 +723,14 @@ internal sealed partial class FluentPresentationBuilder
             {
                 PBT.CopyRelatedSound(_newDocument, oldContentPart, newContentPart, element, R.embed);
             }
+        }
+
+        static void PruneCustDataReference(XElement element)
+        {
+            var parent = element.Parent;
+            element.Remove();
+            if (parent?.Name == P.custDataLst && !parent.HasElements)
+                parent.Remove();
         }
 
         // VML drawing parts use implicit relationships (not element-based) and are handled separately.

--- a/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
+++ b/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
@@ -459,6 +459,13 @@ internal sealed partial class FluentPresentationBuilder
                 if (isVmlPart)
                     PBT.CopyRelatedSound(_newDocument, oldContentPart, newContentPart, element, R.embed);
             }
+            else if (name == A1611.picAttrSrcUrl)
+            {
+                // <a1611:picAttrSrcUrl r:id="..."/> sits inside <a:blip><a:extLst> and carries
+                // an r:id pointing to the original online-image source URL relationship.
+                // It must be rewritten just like any other image relationship reference.
+                CopyRelatedImage(oldContentPart, newContentPart, element, R.id);
+            }
             else if (name == A14.imgLayer)
             {
                 PBT.CopyExtendedPart(oldContentPart, newContentPart, element, R.embed);

--- a/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
+++ b/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
@@ -677,9 +677,19 @@ internal sealed partial class FluentPresentationBuilder
                     // Buffer into memory: lets us check length AND rewind regardless of
                     // whether the underlying stream is seekable (DeflateStream from a
                     // file-backed package is not seekable).
-                    using var srcStream = oldPartIdPair9.OpenXmlPart.GetStream();
                     using var buf = new MemoryStream();
-                    srcStream.CopyTo(buf);
+                    try
+                    {
+                        using var srcStream = oldPartIdPair9.OpenXmlPart.GetStream();
+                        srcStream.CopyTo(buf);
+                    }
+                    catch (InvalidDataException)
+                    {
+                        // Preserve FeedDataFrom's corrupt-ZIP behavior: treat unreadable
+                        // CustomXml content as empty and drop its dangling p:custData reference.
+                        buf.SetLength(0);
+                    }
+
                     if (buf.Length == 0)
                     {
                         // Remove the referencing <p:custData> element and prune an empty

--- a/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
+++ b/Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs
@@ -674,23 +674,34 @@ internal sealed partial class FluentPresentationBuilder
                     // will make PowerPoint show a repair dialog when it opens the output file.
                     // Such parts are occasionally produced by SharePoint/AI generators and carry
                     // no meaningful content, so dropping them is safe.
-                    // Buffer into memory: lets us check length AND rewind regardless of
-                    // whether the underlying stream is seekable (DeflateStream from a
-                    // file-backed package is not seekable).
-                    using var buf = new MemoryStream();
+                    CustomXmlPart newPart = null;
+                    var skipCustomXmlPart = false;
                     try
                     {
                         using var srcStream = oldPartIdPair9.OpenXmlPart.GetStream();
-                        srcStream.CopyTo(buf);
+                        var firstByte = srcStream.ReadByte();
+                        if (firstByte < 0)
+                        {
+                            skipCustomXmlPart = true;
+                        }
+                        else
+                        {
+                            newPart = _newDocument.PresentationPart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
+                            using var dstStream = newPart.GetStream(FileMode.Create, FileAccess.Write);
+                            dstStream.WriteByte((byte)firstByte);
+                            srcStream.CopyTo(dstStream);
+                        }
                     }
                     catch (InvalidDataException)
                     {
                         // Preserve FeedDataFrom's corrupt-ZIP behavior: treat unreadable
                         // CustomXml content as empty and drop its dangling p:custData reference.
-                        buf.SetLength(0);
+                        if (newPart is not null)
+                            _newDocument.PresentationPart.DeletePart(newPart);
+                        skipCustomXmlPart = true;
                     }
 
-                    if (buf.Length == 0)
+                    if (skipCustomXmlPart)
                     {
                         // Remove the referencing <p:custData> element and prune an empty
                         // <p:custDataLst> parent so the slide XML doesn't keep a dangling relId.
@@ -701,9 +712,6 @@ internal sealed partial class FluentPresentationBuilder
                         continue;
                     }
 
-                    var newPart = _newDocument.PresentationPart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
-                    buf.Position = 0;
-                    newPart.FeedData(buf);
                     foreach (
                         var itemProps in oldPartIdPair9.OpenXmlPart.Parts.Where(p =>
                             p.OpenXmlPart.ContentType

--- a/Clippit/PtOpenXmlUtil.cs
+++ b/Clippit/PtOpenXmlUtil.cs
@@ -4228,6 +4228,12 @@ listSeparator
         public static readonly XName svgBlip = svg + "svgBlip";
     }
 
+    public static class A1611
+    {
+        public static readonly XNamespace a1611 = "http://schemas.microsoft.com/office/drawing/2016/11/main";
+        public static readonly XName picAttrSrcUrl = a1611 + "picAttrSrcUrl";
+    }
+
     public static class Plegacy
     {
         public static readonly XNamespace plegacy = "urn:schemas-microsoft-com:office:powerpoint";


### PR DESCRIPTION
## Summary
- Copy a1611:picAttrSrcUrl online-image relationship IDs when publishing slides.
- Drop zero-byte custom XML parts referenced by p:custData and prune dangling p:custDataLst markup to avoid PowerPoint repair prompts.
- Normalize non-standard SVG image MIME type image/svg to image/svg+xml during image copy.
- Bump CLI changelog to 0.1.2 for the next package publish.

## Fixed Issues
- Online image source URL relationships were not rewritten, leaving copied slides with stale r:id references.
- Empty custom XML parts could be copied into generated decks and trigger PowerPoint repair dialogs.
- Mixed/non-standard SVG content types could produce package inconsistencies that PowerPoint repairs.

## Validation
- dotnet csharpier format Clippit/PowerPoint/Fluent/FluentPresentationBuilder.Copy.cs Clippit.Tests/PowerPoint/PresentationBuilderSlidePublishingTests.Fluent.cs
- dotnet test --project Clippit.Tests/ --treenode-filter "/*/*/PresentationBuilderSlidePublishingTests/*CustData*"
- dotnet run --project Clippit.Cli/Clippit.Cli.csproj -- version --format json