### PR TITLE
[Clippy] feat: add README for Clippit.Cli NuGet tool and npm clippit package

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.3] - 2026-06-03
+
+Add README and CLI usage documentation to npm and NuGet packages.
+
 ## [0.1.2] - 2026-06-02
 
 Patch release for the next CLI package publish.

--- a/Clippit.Cli/Clippit.Cli.csproj
+++ b/Clippit.Cli/Clippit.Cli.csproj
@@ -19,6 +19,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/sergey-tihon/Clippit</PackageProjectUrl>
     <PackageIcon>logo.jpeg</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- NativeAOT — only when explicitly requested (e.g. npm binary publish pipeline).
          dotnet tool NuGet (dotnet pack / dotnet tool install) ships a managed DLL
@@ -37,6 +38,7 @@
 
   <ItemGroup>
     <None Include="..\docs\images\logo.jpeg" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -1,0 +1,60 @@
+# Clippit CLI — `dotnet tool`
+
+**Clippit CLI** is a command-line tool for working with OpenXml files (PowerPoint, Word, Excel), built on [Clippit](https://github.com/sergey-tihon/Clippit) — the .NET OpenXml PowerTools library.
+
+## Installation
+
+```bash
+dotnet tool install -g Clippit.Cli
+```
+
+## Quick Start
+
+```bash
+# Split a deck into individual slides
+clippit pptx split presentation.pptx --output ./slides/
+
+# Build a deck from a manifest
+clippit pptx build run manifest.json --output result.pptx
+
+# Validate a PPTX file
+clippit pptx verify presentation.pptx
+
+# Get JSON output for scripting
+clippit pptx split presentation.pptx --format json
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `pptx split` | Split a `.pptx` into individual single-slide files. Supports slide range selection (`--slides`) and manifest generation (`--manifest`). |
+| `pptx build init` | Scaffold a deck manifest (JSON). |
+| `pptx build run` | Assemble a `.pptx` from a deck manifest. |
+| `pptx verify` | Validate a PPTX — schema, relationships, markup compatibility, and sections. |
+| `version` | Print version information. |
+
+### Common flags
+
+| Flag | Description |
+|------|-------------|
+| `--format json\|text` | Structured JSON or human-readable output (default: `text`) |
+| `--quiet` / `-q` | Suppress success output; exit codes still reflect result |
+| `--force` | Overwrite existing output files |
+| `-` | Use stdin / stdout for piped workflows |
+
+## Machine-readable output
+
+Success payloads → **stdout** (compact JSON when `--format json` or stdout is piped).  
+Command errors → **stderr** (compact JSON with a stable symbolic `code`).
+
+Published JSON schemas for manifests and result payloads are available at  
+[`docs/schemas/`](https://github.com/sergey-tihon/Clippit/tree/main/docs/schemas).
+
+## Full documentation
+
+➡️ **[https://sergey-tihon.github.io/Clippit/cli.html](https://sergey-tihon.github.io/Clippit/cli.html)**
+
+## License
+
+MIT © [Sergey Tihon](https://github.com/sergey-tihon)

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -38,7 +38,7 @@ clippit pptx split presentation.pptx --format json
 
 | Flag | Description |
 |------|-------------|
-| `--format json\|text` | Structured JSON or human-readable output (default: `text`) |
+| `--format json|text` | Structured JSON or human-readable output (default: `text`) |
 | `--quiet` / `-q` | Suppress success output; exit codes still reflect result |
 | `--force` | Overwrite existing output files |
 | `-` | Use stdin / stdout for piped workflows |

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -1,0 +1,76 @@
+# clippit
+
+**Clippit CLI** is a command-line tool for working with OpenXml files (PowerPoint, Word, Excel).  
+This npm package provides native binaries for all platforms — no .NET runtime required.
+
+## Installation
+
+```bash
+npm install -g clippit
+```
+
+## Quick Start
+
+```bash
+# Split a deck into individual slides
+clippit pptx split presentation.pptx --output ./slides/
+
+# Build a deck from a manifest
+clippit pptx build run manifest.json --output result.pptx
+
+# Validate a PPTX file
+clippit pptx verify presentation.pptx
+
+# Get JSON output for scripting
+clippit pptx split presentation.pptx --format json
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `pptx split` | Split a `.pptx` into individual single-slide files. Supports slide range selection (`--slides`) and manifest generation (`--manifest`). |
+| `pptx build init` | Scaffold a deck manifest (JSON). |
+| `pptx build run` | Assemble a `.pptx` from a deck manifest. |
+| `pptx verify` | Validate a PPTX — schema, relationships, markup compatibility, and sections. |
+| `version` | Print version information. |
+
+### Common flags
+
+| Flag | Description |
+|------|-------------|
+| `--format json\|text` | Structured JSON or human-readable output (default: `text`) |
+| `--quiet` / `-q` | Suppress success output; exit codes still reflect result |
+| `--force` | Overwrite existing output files |
+| `-` | Use stdin / stdout for piped workflows |
+
+## Machine-readable output
+
+Success payloads → **stdout** (compact JSON when `--format json` or stdout is piped).  
+Command errors → **stderr** (compact JSON with a stable symbolic `code`).
+
+Published JSON schemas for manifests and result payloads are available at  
+[`docs/schemas/`](https://github.com/sergey-tihon/Clippit/tree/main/docs/schemas).
+
+## Supported platforms
+
+| Platform | Package |
+|----------|---------|
+| Windows x64 | `@sergey-tihon/clippit-bin-win32-x64` |
+| macOS x64 | `@sergey-tihon/clippit-bin-darwin-x64` |
+| macOS arm64 | `@sergey-tihon/clippit-bin-darwin-arm64` |
+| Linux x64 | `@sergey-tihon/clippit-bin-linux-x64` |
+
+The correct binary package is installed automatically as an optional dependency.
+
+## Full documentation
+
+➡️ **[https://sergey-tihon.github.io/Clippit/cli.html](https://sergey-tihon.github.io/Clippit/cli.html)**
+
+## dotnet tool
+
+Prefer .NET? Install via: `dotnet tool install -g Clippit.Cli`
+
+## License
+
+MIT © [Sergey Tihon](https://github.com/sergey-tihon)

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -39,7 +39,7 @@ clippit pptx split presentation.pptx --format json
 
 | Flag | Description |
 |------|-------------|
-| `--format json\|text` | Structured JSON or human-readable output (default: `text`) |
+| `--format json|text` | Structured JSON or human-readable output (default: `text`) |
 | `--quiet` / `-q` | Suppress success output; exit codes still reflect result |
 | `--force` | Overwrite existing output files |
 | `-` | Use stdin / stdout for piped workflows |

--- a/npm/clippit/package.json
+++ b/npm/clippit/package.json
@@ -17,7 +17,8 @@
   "files": [
     "bin/",
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "README.md"
   ],
   "optionalDependencies": {
     "@sergey-tihon/clippit-bin-win32-x64": "0.0.0",


### PR DESCRIPTION
Closes #318

- Add Clippit.Cli/README.md with install instructions, command reference,
  flags, machine-readable output docs, and link to full CLI docs.
- Wire PackageReadmeFile in Clippit.Cli.csproj so NuGet displays the README.
- Add npm/clippit/README.md with the same content adapted for npm audience,
  including platform binary table.
- Add README.md to npm/clippit/package.json files list so it's included in
  the published package.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
