### PR TITLE
feat(cli): add word verify and excel verify commands

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.0] - 2026-06-05
+
+- Added `word verify` command to validate `.docx` files.
+- Added `excel verify` command to validate `.xlsx` files.
+
 ## [0.1.3] - 2026-06-03
 
 Add README and CLI usage documentation to npm and NuGet packages.

--- a/Clippit.Cli/CliJsonContext.cs
+++ b/Clippit.Cli/CliJsonContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Clippit.Cli.Commands.Common.Verify;
 using Clippit.Cli.Commands.Pptx.Build;
 using Clippit.Cli.Commands.Pptx.Split;
 using Clippit.Cli.Commands.Pptx.Verify;

--- a/Clippit.Cli/Commands/Common/Verify/VerifyExecutor.cs
+++ b/Clippit.Cli/Commands/Common/Verify/VerifyExecutor.cs
@@ -1,0 +1,77 @@
+using System.Xml;
+using Clippit.Cli.Infrastructure;
+using Clippit.Core;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Cli.Commands.Common.Verify;
+
+/// <summary>
+/// Shared execution pipeline for the <c>pptx verify</c>, <c>word verify</c>, and
+/// <c>excel verify</c> commands. Opens the input stream, runs a caller-supplied
+/// validator delegate, converts package-open failures into a <c>package</c>
+/// diagnostic on the result, and projects diagnostics into the CLI's
+/// <see cref="VerifyDiagnostic"/> shape.
+/// </summary>
+internal static class VerifyExecutor
+{
+    public static VerifyResult Execute(
+        InputSource input,
+        FileFormatVersions officeVersion,
+        Func<Stream, OpenXmlValidationResult> validate
+    )
+    {
+        var inputStream = input.OpenSeekable();
+        using (inputStream)
+        {
+            OpenXmlValidationResult validation;
+            try
+            {
+                validation = validate(inputStream);
+            }
+            catch (Exception ex)
+                when (ex
+                        is OpenXmlPackageException
+                            or FileFormatException
+                            or InvalidDataException
+                            or XmlException
+                            or FormatException
+                )
+            {
+                validation = new OpenXmlValidationResult
+                {
+                    OfficeVersion = officeVersion,
+                    Diagnostics =
+                    [
+                        new OpenXmlValidationDiagnostic
+                        {
+                            Kind = OpenXmlValidationDiagnosticKinds.Package,
+                            Description = ex.Message,
+                        },
+                    ],
+                };
+            }
+
+            return new VerifyResult
+            {
+                Input = input.DisplayName,
+                OfficeVersion = validation.OfficeVersion.ToString(),
+                Valid = validation.Valid,
+                Diagnostics = validation.Diagnostics.Select(ToVerifyDiagnostic).ToList(),
+            };
+        }
+    }
+
+    private static VerifyDiagnostic ToVerifyDiagnostic(OpenXmlValidationDiagnostic diagnostic) =>
+        new()
+        {
+            Kind = diagnostic.Kind,
+            Code = diagnostic.Code,
+            Description = diagnostic.Description,
+            Part = diagnostic.Part,
+            Path = diagnostic.Path,
+            Element = diagnostic.Element,
+            Attribute = diagnostic.Attribute,
+            RelationshipId = diagnostic.RelationshipId,
+        };
+}

--- a/Clippit.Cli/Commands/Common/Verify/VerifyResult.cs
+++ b/Clippit.Cli/Commands/Common/Verify/VerifyResult.cs
@@ -1,7 +1,7 @@
-namespace Clippit.Cli.Commands.Pptx.Verify;
+namespace Clippit.Cli.Commands.Common.Verify;
 
 /// <summary>
-/// Result of the "pptx verify" command.
+/// Result of the "verify" command for Word, Excel, or PowerPoint documents.
 /// </summary>
 internal sealed record VerifyResult
 {
@@ -12,7 +12,7 @@ internal sealed record VerifyResult
 
     public static void WriteText(VerifyResult result, TextWriter writer)
     {
-        writer.WriteLine($"{(result.Valid ? "Valid" : "Invalid")} PPTX: {result.Input}");
+        writer.WriteLine($"{(result.Valid ? "Valid" : "Invalid")} document: {result.Input}");
         writer.WriteLine($"Office version: {result.OfficeVersion}");
 
         if (result.Valid)

--- a/Clippit.Cli/Commands/Excel/ExcelCommand.cs
+++ b/Clippit.Cli/Commands/Excel/ExcelCommand.cs
@@ -1,0 +1,17 @@
+using System.CommandLine;
+using Clippit.Cli.Commands.Excel.Verify;
+
+namespace Clippit.Cli.Commands.Excel;
+
+/// <summary>
+/// Root "excel" subcommand group — all Excel (.xlsx) operations live here.
+/// </summary>
+internal static class ExcelCommand
+{
+    public static Command Build()
+    {
+        var cmd = new Command("excel", "Work with Excel (.xlsx) files");
+        cmd.Subcommands.Add(ExcelVerifyCommand.Build());
+        return cmd;
+    }
+}

--- a/Clippit.Cli/Commands/Excel/Verify/ExcelVerifyCommand.cs
+++ b/Clippit.Cli/Commands/Excel/Verify/ExcelVerifyCommand.cs
@@ -3,9 +3,9 @@ using Clippit.Cli.Commands.Common.Verify;
 using Clippit.Cli.Infrastructure;
 using DocumentFormat.OpenXml;
 
-namespace Clippit.Cli.Commands.Pptx.Verify;
+namespace Clippit.Cli.Commands.Excel.Verify;
 
-internal static class PptxVerifyCommand
+internal static class ExcelVerifyCommand
 {
     private const FileFormatVersions DefaultOfficeVersion = FileFormatVersions.Microsoft365;
     private static readonly string s_allowedOfficeVersions = string.Join(
@@ -17,7 +17,7 @@ internal static class PptxVerifyCommand
     {
         var inputArg = InputSource.BuildArgument(
             "input",
-            "Path to the .pptx file to verify. Use '-' to read from stdin."
+            "Path to the .xlsx file to verify. Use '-' to read from stdin."
         );
 
         var officeVersionOption = new Option<string>("--office-version")
@@ -39,12 +39,12 @@ internal static class PptxVerifyCommand
 
         var cmd = new Command(
             "verify",
-            "Validate that a .pptx file is a correct OpenXml presentation."
+            "Validate that a .xlsx file is a correct OpenXml spreadsheet."
                 + "\n\nExamples:"
-                + "\n  clippit pptx verify deck.pptx"
-                + "\n  clippit pptx verify deck.pptx --format json"
-                + "\n  clippit pptx verify deck.pptx --office-version Office2021"
-                + "\n  cat deck.pptx | clippit pptx verify - --format json"
+                + "\n  clippit excel verify spreadsheet.xlsx"
+                + "\n  clippit excel verify spreadsheet.xlsx --format json"
+                + "\n  clippit excel verify spreadsheet.xlsx --office-version Office2021"
+                + "\n  cat spreadsheet.xlsx | clippit excel verify - --format json"
         );
         cmd.Arguments.Add(inputArg);
         cmd.Options.Add(officeVersionOption);
@@ -67,8 +67,8 @@ internal static class PptxVerifyCommand
     private static int Run(string inputPath, FileFormatVersions officeVersion, OutputFormat format, bool quiet)
     {
         var writer = new OutputWriter(format, quiet);
-        var input = InputSource.From(inputPath, "stdin.pptx");
-        var result = PptxVerifyService.Execute(input, officeVersion);
+        var input = InputSource.From(inputPath, "stdin.xlsx");
+        var result = ExcelVerifyService.Execute(input, officeVersion);
         writer.WriteResult(result, CliJsonContext.Default.VerifyResult, VerifyResult.WriteText);
         return result.Valid ? ExitCodes.Success : ExitCodes.InvalidFormat;
     }

--- a/Clippit.Cli/Commands/Excel/Verify/ExcelVerifyService.cs
+++ b/Clippit.Cli/Commands/Excel/Verify/ExcelVerifyService.cs
@@ -1,0 +1,28 @@
+using Clippit.Cli.Commands.Common.Verify;
+using Clippit.Cli.Infrastructure;
+using Clippit.Core;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Cli.Commands.Excel.Verify;
+
+internal static class ExcelVerifyService
+{
+    public static VerifyResult Execute(InputSource input, FileFormatVersions officeVersion) =>
+        VerifyExecutor.Execute(
+            input,
+            officeVersion,
+            stream =>
+            {
+                using var document = SpreadsheetDocument.Open(
+                    stream,
+                    isEditable: false,
+                    new OpenSettings { AutoSave = false }
+                );
+                return OpenXmlPackageValidator.Validate(
+                    document,
+                    new OpenXmlValidationOptions { OfficeVersion = officeVersion }
+                );
+            }
+        );
+}

--- a/Clippit.Cli/Commands/Pptx/Verify/PptxVerifyService.cs
+++ b/Clippit.Cli/Commands/Pptx/Verify/PptxVerifyService.cs
@@ -1,3 +1,4 @@
+using Clippit.Cli.Commands.Common.Verify;
 using Clippit.Cli.Infrastructure;
 using Clippit.Core;
 using Clippit.PowerPoint;
@@ -7,37 +8,11 @@ namespace Clippit.Cli.Commands.Pptx.Verify;
 
 internal static class PptxVerifyService
 {
-    public static VerifyResult Execute(InputSource input, FileFormatVersions officeVersion)
-    {
-        var inputStream = input.OpenSeekable();
-        using (inputStream)
-        {
-            var validation = PresentationValidator.Validate(
-                inputStream,
-                new OpenXmlValidationOptions { OfficeVersion = officeVersion }
-            );
-            var diagnostics = validation.Diagnostics.Select(ToVerifyDiagnostic).ToList();
-
-            return new VerifyResult
-            {
-                Input = input.DisplayName,
-                OfficeVersion = validation.OfficeVersion.ToString(),
-                Valid = validation.Valid,
-                Diagnostics = diagnostics,
-            };
-        }
-    }
-
-    private static VerifyDiagnostic ToVerifyDiagnostic(OpenXmlValidationDiagnostic diagnostic) =>
-        new()
-        {
-            Kind = diagnostic.Kind,
-            Code = diagnostic.Code,
-            Description = diagnostic.Description,
-            Part = diagnostic.Part,
-            Path = diagnostic.Path,
-            Element = diagnostic.Element,
-            Attribute = diagnostic.Attribute,
-            RelationshipId = diagnostic.RelationshipId,
-        };
+    public static VerifyResult Execute(InputSource input, FileFormatVersions officeVersion) =>
+        VerifyExecutor.Execute(
+            input,
+            officeVersion,
+            stream =>
+                PresentationValidator.Validate(stream, new OpenXmlValidationOptions { OfficeVersion = officeVersion })
+        );
 }

--- a/Clippit.Cli/Commands/Word/Verify/WordVerifyCommand.cs
+++ b/Clippit.Cli/Commands/Word/Verify/WordVerifyCommand.cs
@@ -3,9 +3,9 @@ using Clippit.Cli.Commands.Common.Verify;
 using Clippit.Cli.Infrastructure;
 using DocumentFormat.OpenXml;
 
-namespace Clippit.Cli.Commands.Pptx.Verify;
+namespace Clippit.Cli.Commands.Word.Verify;
 
-internal static class PptxVerifyCommand
+internal static class WordVerifyCommand
 {
     private const FileFormatVersions DefaultOfficeVersion = FileFormatVersions.Microsoft365;
     private static readonly string s_allowedOfficeVersions = string.Join(
@@ -17,7 +17,7 @@ internal static class PptxVerifyCommand
     {
         var inputArg = InputSource.BuildArgument(
             "input",
-            "Path to the .pptx file to verify. Use '-' to read from stdin."
+            "Path to the .docx file to verify. Use '-' to read from stdin."
         );
 
         var officeVersionOption = new Option<string>("--office-version")
@@ -39,12 +39,12 @@ internal static class PptxVerifyCommand
 
         var cmd = new Command(
             "verify",
-            "Validate that a .pptx file is a correct OpenXml presentation."
+            "Validate that a .docx file is a correct OpenXml document."
                 + "\n\nExamples:"
-                + "\n  clippit pptx verify deck.pptx"
-                + "\n  clippit pptx verify deck.pptx --format json"
-                + "\n  clippit pptx verify deck.pptx --office-version Office2021"
-                + "\n  cat deck.pptx | clippit pptx verify - --format json"
+                + "\n  clippit word verify document.docx"
+                + "\n  clippit word verify document.docx --format json"
+                + "\n  clippit word verify document.docx --office-version Office2021"
+                + "\n  cat document.docx | clippit word verify - --format json"
         );
         cmd.Arguments.Add(inputArg);
         cmd.Options.Add(officeVersionOption);
@@ -67,8 +67,8 @@ internal static class PptxVerifyCommand
     private static int Run(string inputPath, FileFormatVersions officeVersion, OutputFormat format, bool quiet)
     {
         var writer = new OutputWriter(format, quiet);
-        var input = InputSource.From(inputPath, "stdin.pptx");
-        var result = PptxVerifyService.Execute(input, officeVersion);
+        var input = InputSource.From(inputPath, "stdin.docx");
+        var result = WordVerifyService.Execute(input, officeVersion);
         writer.WriteResult(result, CliJsonContext.Default.VerifyResult, VerifyResult.WriteText);
         return result.Valid ? ExitCodes.Success : ExitCodes.InvalidFormat;
     }

--- a/Clippit.Cli/Commands/Word/Verify/WordVerifyService.cs
+++ b/Clippit.Cli/Commands/Word/Verify/WordVerifyService.cs
@@ -1,0 +1,28 @@
+using Clippit.Cli.Commands.Common.Verify;
+using Clippit.Cli.Infrastructure;
+using Clippit.Core;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Cli.Commands.Word.Verify;
+
+internal static class WordVerifyService
+{
+    public static VerifyResult Execute(InputSource input, FileFormatVersions officeVersion) =>
+        VerifyExecutor.Execute(
+            input,
+            officeVersion,
+            stream =>
+            {
+                using var document = WordprocessingDocument.Open(
+                    stream,
+                    isEditable: false,
+                    new OpenSettings { AutoSave = false }
+                );
+                return OpenXmlPackageValidator.Validate(
+                    document,
+                    new OpenXmlValidationOptions { OfficeVersion = officeVersion }
+                );
+            }
+        );
+}

--- a/Clippit.Cli/Commands/Word/WordCommand.cs
+++ b/Clippit.Cli/Commands/Word/WordCommand.cs
@@ -1,0 +1,17 @@
+using System.CommandLine;
+using Clippit.Cli.Commands.Word.Verify;
+
+namespace Clippit.Cli.Commands.Word;
+
+/// <summary>
+/// Root "word" subcommand group — all Word (.docx) operations live here.
+/// </summary>
+internal static class WordCommand
+{
+    public static Command Build()
+    {
+        var cmd = new Command("word", "Work with Word (.docx) files");
+        cmd.Subcommands.Add(WordVerifyCommand.Build());
+        return cmd;
+    }
+}

--- a/Clippit.Cli/Program.cs
+++ b/Clippit.Cli/Program.cs
@@ -1,12 +1,16 @@
 using System.CommandLine;
 using System.Text.Json;
 using Clippit.Cli;
+using Clippit.Cli.Commands.Excel;
 using Clippit.Cli.Commands.Pptx;
 using Clippit.Cli.Commands.Version;
+using Clippit.Cli.Commands.Word;
 
 var rootCommand = new RootCommand("Clippit — PowerTools CLI for OpenXml (PowerPoint, Word, Excel)");
 
 rootCommand.Subcommands.Add(PptxCommand.Build());
+rootCommand.Subcommands.Add(WordCommand.Build());
+rootCommand.Subcommands.Add(ExcelCommand.Build());
 rootCommand.Subcommands.Add(VersionCommand.Build());
 
 args = NormalizeHelpArgs(args);

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -20,6 +20,12 @@ clippit pptx build run manifest.json --output result.pptx
 # Validate a PPTX file
 clippit pptx verify presentation.pptx
 
+# Validate a DOCX file
+clippit word verify document.docx
+
+# Validate an XLSX file
+clippit excel verify spreadsheet.xlsx
+
 # Get JSON output for scripting
 clippit pptx split presentation.pptx --format json
 ```
@@ -32,6 +38,8 @@ clippit pptx split presentation.pptx --format json
 | `pptx build init` | Scaffold a deck manifest (JSON). |
 | `pptx build run` | Assemble a `.pptx` from a deck manifest. |
 | `pptx verify` | Validate a PPTX — schema, relationships, markup compatibility, and sections. |
+| `word verify` | Validate a DOCX — schema and relationships. |
+| `excel verify` | Validate an XLSX — schema and relationships. |
 | `version` | Print version information. |
 
 ### Common flags

--- a/Clippit.Tests/Cli/Integration/Excel/ExcelVerifyTests.cs
+++ b/Clippit.Tests/Cli/Integration/Excel/ExcelVerifyTests.cs
@@ -1,0 +1,188 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace Clippit.Tests.Cli.Integration.Excel;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class ExcelVerifyTests : CliIntegrationTestBase
+{
+    [Test]
+    public async Task CLI051_ExcelVerify_ValidSpreadsheet_ReturnsValidJson()
+    {
+        var input = CliTestRunner.TestFile("SH001-Table.xlsx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "verify", input.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo(input.FullName);
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Microsoft365");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsTrue();
+        await Assert.That(json.RootElement.GetProperty("diagnostics").GetArrayLength()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CLI052_ExcelVerify_NonXlsx_ReturnsInvalidResultOnStdout()
+    {
+        var directory = CliTestRunner.CreateTempDirectory("verify-invalid-package");
+        var input = new FileInfo(Path.Combine(directory.FullName, "not-a-spreadsheet.xlsx"));
+        await File.WriteAllTextAsync(input.FullName, "not a zip package").ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "verify", input.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Microsoft365");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsFalse();
+        await Assert
+            .That(json.RootElement.GetProperty("diagnostics")[0].GetProperty("kind").GetString())
+            .IsEqualTo("package");
+    }
+
+    [Test]
+    public async Task CLI053_ExcelVerify_DanglingRelationship_ReturnsRelationshipDiagnostic()
+    {
+        var directory = CliTestRunner.CreateTempDirectory("verify-dangling-rel");
+        var input = new FileInfo(Path.Combine(directory.FullName, "dangling.xlsx"));
+        File.Copy(CliTestRunner.TestFile("SH001-Table.xlsx").FullName, input.FullName);
+        InjectDanglingRelationship(input, "rId_cli_verify_dangling");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "verify", input.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsFalse();
+
+        var diagnostics = json.RootElement.GetProperty("diagnostics");
+        var relationshipErrorFound = false;
+        for (var i = 0; i < diagnostics.GetArrayLength(); i++)
+        {
+            var diagnostic = diagnostics[i];
+            if (
+                diagnostic.GetProperty("kind").GetString() == "relationship"
+                && diagnostic.GetProperty("relationshipId").GetString() == "rId_cli_verify_dangling"
+            )
+            {
+                relationshipErrorFound = true;
+            }
+        }
+        await Assert.That(relationshipErrorFound).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI054_ExcelVerify_ReadsFromStdin()
+    {
+        var input = CliTestRunner.TestFile("SH001-Table.xlsx");
+        var bytes = await File.ReadAllBytesAsync(input.FullName).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(bytes, "excel", "verify", "-", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var stdout = System.Text.Encoding.UTF8.GetString(result.StandardOutput);
+        using var json = JsonDocument.Parse(stdout);
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo("<stdin>");
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Microsoft365");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI054a_ExcelVerify_OfficeVersionOverride_IsReported()
+    {
+        var input = CliTestRunner.TestFile("SH001-Table.xlsx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "verify", input.FullName, "--office-version", "Office2021", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Office2021");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI054b_ExcelVerify_InvalidOfficeVersion_ReturnsParserError()
+    {
+        var input = CliTestRunner.TestFile("SH001-Table.xlsx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "verify", input.FullName, "--office-version", "Office2099", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(1);
+        await Assert.That(result.StandardOutput).Contains("Usage:");
+        await Assert.That(result.StandardError).Contains("Invalid value for --office-version: 'Office2099'.");
+    }
+
+    [Test]
+    public async Task CLI054c_ExcelVerify_StrictOption_IsUnknownOption()
+    {
+        var input = CliTestRunner.TestFile("SH001-Table.xlsx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "verify", input.FullName, "--strict", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(1);
+        await Assert.That(result.StandardOutput).Contains("Usage:");
+        await Assert.That(result.StandardError).Contains("Unrecognized command or argument '--strict'");
+    }
+
+    [Test]
+    public async Task CLI055_ExcelVerify_QuietSuppressesStdoutButPreservesExitCode()
+    {
+        var input = CliTestRunner.TestFile("SH001-Table.xlsx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "verify", input.FullName, "--quiet", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).IsEmpty();
+    }
+
+    private static void InjectDanglingRelationship(FileInfo xlsx, params string[] danglingIds)
+    {
+        XNamespace sNs = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        XNamespace rNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+        using var zip = ZipFile.Open(xlsx.FullName, ZipArchiveMode.Update);
+        var sheetEntry = zip.GetEntry("xl/worksheets/sheet1.xml")!;
+
+        XDocument xDoc;
+        using (var stream = sheetEntry.Open())
+            xDoc = XDocument.Load(stream);
+
+        var target = xDoc.Descendants(sNs + "sheetData").FirstOrDefault() ?? xDoc.Root;
+        foreach (var danglingId in danglingIds)
+            target?.Add(new XElement(sNs + "row", new XAttribute(rNs + "id", danglingId)));
+
+        var fullName = sheetEntry.FullName;
+        sheetEntry.Delete();
+        var newEntry = zip.CreateEntry(fullName);
+        using var writer = new StreamWriter(newEntry.Open());
+        using var xmlWriter = System.Xml.XmlWriter.Create(writer);
+        xDoc.WriteTo(xmlWriter);
+    }
+}
+#pragma warning restore CA1707

--- a/Clippit.Tests/Cli/Integration/Word/WordVerifyTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordVerifyTests.cs
@@ -1,0 +1,188 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace Clippit.Tests.Cli.Integration.Word;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class WordVerifyTests : CliIntegrationTestBase
+{
+    [Test]
+    public async Task CLI041_WordVerify_ValidDocument_ReturnsValidJson()
+    {
+        var input = CliTestRunner.TestFile("HC001-5DayTourPlanTemplate.docx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "verify", input.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo(input.FullName);
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Microsoft365");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsTrue();
+        await Assert.That(json.RootElement.GetProperty("diagnostics").GetArrayLength()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CLI042_WordVerify_NonDocx_ReturnsInvalidResultOnStdout()
+    {
+        var directory = CliTestRunner.CreateTempDirectory("verify-invalid-package");
+        var input = new FileInfo(Path.Combine(directory.FullName, "not-a-document.docx"));
+        await File.WriteAllTextAsync(input.FullName, "not a zip package").ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "verify", input.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Microsoft365");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsFalse();
+        await Assert
+            .That(json.RootElement.GetProperty("diagnostics")[0].GetProperty("kind").GetString())
+            .IsEqualTo("package");
+    }
+
+    [Test]
+    public async Task CLI043_WordVerify_DanglingRelationship_ReturnsRelationshipDiagnostic()
+    {
+        var directory = CliTestRunner.CreateTempDirectory("verify-dangling-rel");
+        var input = new FileInfo(Path.Combine(directory.FullName, "dangling.docx"));
+        File.Copy(CliTestRunner.TestFile("HC001-5DayTourPlanTemplate.docx").FullName, input.FullName);
+        InjectDanglingRelationship(input, "rId_cli_verify_dangling");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "verify", input.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsFalse();
+
+        var diagnostics = json.RootElement.GetProperty("diagnostics");
+        var relationshipErrorFound = false;
+        for (var i = 0; i < diagnostics.GetArrayLength(); i++)
+        {
+            var diagnostic = diagnostics[i];
+            if (
+                diagnostic.GetProperty("kind").GetString() == "relationship"
+                && diagnostic.GetProperty("relationshipId").GetString() == "rId_cli_verify_dangling"
+            )
+            {
+                relationshipErrorFound = true;
+            }
+        }
+        await Assert.That(relationshipErrorFound).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI044_WordVerify_ReadsFromStdin()
+    {
+        var input = CliTestRunner.TestFile("HC001-5DayTourPlanTemplate.docx");
+        var bytes = await File.ReadAllBytesAsync(input.FullName).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(bytes, "word", "verify", "-", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var stdout = System.Text.Encoding.UTF8.GetString(result.StandardOutput);
+        using var json = JsonDocument.Parse(stdout);
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo("<stdin>");
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Microsoft365");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI044a_WordVerify_OfficeVersionOverride_IsReported()
+    {
+        var input = CliTestRunner.TestFile("HC001-5DayTourPlanTemplate.docx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "verify", input.FullName, "--office-version", "Office2021", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("officeVersion").GetString()).IsEqualTo("Office2021");
+        await Assert.That(json.RootElement.GetProperty("valid").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI044b_WordVerify_InvalidOfficeVersion_ReturnsParserError()
+    {
+        var input = CliTestRunner.TestFile("HC001-5DayTourPlanTemplate.docx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "verify", input.FullName, "--office-version", "Office2099", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(1);
+        await Assert.That(result.StandardOutput).Contains("Usage:");
+        await Assert.That(result.StandardError).Contains("Invalid value for --office-version: 'Office2099'.");
+    }
+
+    [Test]
+    public async Task CLI044c_WordVerify_StrictOption_IsUnknownOption()
+    {
+        var input = CliTestRunner.TestFile("HC001-5DayTourPlanTemplate.docx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "verify", input.FullName, "--strict", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(1);
+        await Assert.That(result.StandardOutput).Contains("Usage:");
+        await Assert.That(result.StandardError).Contains("Unrecognized command or argument '--strict'");
+    }
+
+    [Test]
+    public async Task CLI045_WordVerify_QuietSuppressesStdoutButPreservesExitCode()
+    {
+        var input = CliTestRunner.TestFile("HC001-5DayTourPlanTemplate.docx");
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "verify", input.FullName, "--quiet", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).IsEmpty();
+    }
+
+    private static void InjectDanglingRelationship(FileInfo docx, params string[] danglingIds)
+    {
+        XNamespace wNs = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        XNamespace rNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+        using var zip = ZipFile.Open(docx.FullName, ZipArchiveMode.Update);
+        var docEntry = zip.GetEntry("word/document.xml")!;
+
+        XDocument xDoc;
+        using (var stream = docEntry.Open())
+            xDoc = XDocument.Load(stream);
+
+        var target = xDoc.Descendants(wNs + "body").FirstOrDefault() ?? xDoc.Root;
+        foreach (var danglingId in danglingIds)
+            target?.Add(new XElement(wNs + "p", new XAttribute(rNs + "id", danglingId)));
+
+        var fullName = docEntry.FullName;
+        docEntry.Delete();
+        var newEntry = zip.CreateEntry(fullName);
+        using var writer = new StreamWriter(newEntry.Open());
+        using var xmlWriter = System.Xml.XmlWriter.Create(writer);
+        xDoc.WriteTo(xmlWriter);
+    }
+}
+#pragma warning restore CA1707

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,8 @@ clippit version
 clippit pptx split deck.pptx --output slides --manifest
 clippit pptx build run slides/deck.manifest.json --output final.pptx
 clippit pptx verify final.pptx
+clippit word verify document.docx
+clippit excel verify spreadsheet.xlsx
 ```
 
 ## Installation
@@ -56,6 +58,8 @@ Agents and scripts should use `--format json` when they need machine-readable co
 | ------ | --------- | ------- |
 | stdout | Successful JSON command | Command-specific result JSON. |
 | stdout | `pptx verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
+| stdout | `word verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
+| stdout | `excel verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
 | stdout | `pptx build run --output -` | Binary `.pptx`; no success summary is written. |
 | stderr | Command execution error | Compact JSON error object: `{"error":"...","code":"..."}`. |
 | stderr/stdout | Parser, arity, and help output | System.CommandLine text output, not JSON. |
@@ -81,6 +85,8 @@ Commands that accept files use `-` for stdin where binary or JSON streaming is s
 cat deck.pptx | clippit pptx split - --output slides --format json
 cat deck.json | clippit pptx build run - --output - > final.pptx
 cat deck.pptx | clippit pptx verify - --format json
+cat document.docx | clippit word verify - --format json
+cat spreadsheet.xlsx | clippit excel verify - --format json
 ```
 
 When `pptx build run --output -` writes a `.pptx` to stdout, the success summary is suppressed automatically so the binary stream is not corrupted.
@@ -268,6 +274,68 @@ Invalid JSON example:
 {"input":"/work/deck.pptx","officeVersion":"Microsoft365","valid":false,"diagnostics":[{"kind":"relationship","code":null,"description":"Dangling relationship target.","part":"/ppt/slides/slide1.xml","path":null,"element":null,"attribute":"id","relationshipId":"rId9"}]}
 ```
 
+## `word verify`
+
+Validates that a `.docx` file is a readable and structurally correct Open XML document. The command checks package readability, Open XML schema errors, dangling relationships, and markup compatibility issues.
+
+Synopsis:
+
+```text
+clippit word verify <input.docx|-> [--office-version <version>] [--format json|text] [--quiet]
+```
+
+```bash
+clippit word verify document.docx
+clippit word verify document.docx --format json
+clippit word verify document.docx --office-version Office2021
+cat document.docx | clippit word verify - --format json
+```
+
+Options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--office-version` | Open XML schema version to validate against. Defaults to `Microsoft365`. |
+
+Invalid-but-readable documents produce a validation result on stdout and exit with code `4`. JSON results include `diagnostics`; each diagnostic has a `kind`, message, and optional validator code/location fields. The payload shape matches `pptx verify` and is documented in [schemas/README.md](schemas/README.md).
+
+Valid JSON example:
+
+```json
+{"input":"/work/document.docx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
+```
+
+## `excel verify`
+
+Validates that a `.xlsx` file is a readable and structurally correct Open XML spreadsheet. The command checks package readability, Open XML schema errors, dangling relationships, and markup compatibility issues.
+
+Synopsis:
+
+```text
+clippit excel verify <input.xlsx|-> [--office-version <version>] [--format json|text] [--quiet]
+```
+
+```bash
+clippit excel verify spreadsheet.xlsx
+clippit excel verify spreadsheet.xlsx --format json
+clippit excel verify spreadsheet.xlsx --office-version Office2021
+cat spreadsheet.xlsx | clippit excel verify - --format json
+```
+
+Options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--office-version` | Open XML schema version to validate against. Defaults to `Microsoft365`. |
+
+Invalid-but-readable spreadsheets produce a validation result on stdout and exit with code `4`. JSON results include `diagnostics`; each diagnostic has a `kind`, message, and optional validator code/location fields. The payload shape matches `pptx verify` and is documented in [schemas/README.md](schemas/README.md).
+
+Valid JSON example:
+
+```json
+{"input":"/work/spreadsheet.xlsx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
+```
+
 ## JSON Schemas
 
 Schemas for deck manifests and CLI result payloads are published in [docs/schemas](schemas/README.md). Result schemas are intended for documentation, integration tests, and downstream contract validation; result payloads do not embed schema URLs.
@@ -279,4 +347,4 @@ Canonical schema URLs:
 | Deck manifest | `https://sergey-tihon.github.io/Clippit/schemas/deck-manifest.v1.json` |
 | `pptx split` result | `https://sergey-tihon.github.io/Clippit/schemas/split-result.v1.json` |
 | `pptx build run` result | `https://sergey-tihon.github.io/Clippit/schemas/build-result.v1.json` |
-| `pptx verify` result | `https://sergey-tihon.github.io/Clippit/schemas/verify-result.v1.json` |
+| `pptx verify`, `word verify`, `excel verify` result | `https://sergey-tihon.github.io/Clippit/schemas/verify-result.v1.json` |

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -13,7 +13,7 @@ published for documentation, integration validation, and contract tests.
 | [`deck-manifest.v1.json`](./deck-manifest.v1.json)   | Input manifest consumed by `clippit pptx build run`        |
 | [`split-result.v1.json`](./split-result.v1.json)     | Stdout payload of `clippit pptx split` (JSON mode)         |
 | [`build-result.v1.json`](./build-result.v1.json)     | Stdout payload of `clippit pptx build run` (JSON mode)     |
-| [`verify-result.v1.json`](./verify-result.v1.json)   | Stdout payload of `clippit pptx verify` (JSON mode)        |
+| [`verify-result.v1.json`](./verify-result.v1.json)   | Stdout payload of `clippit pptx verify`, `clippit word verify`, `clippit excel verify` (JSON mode) |
 
 ## Output discipline
 
@@ -31,10 +31,11 @@ published for documentation, integration validation, and contract tests.
 
   Parser/help errors come from System.CommandLine and may include usage text.
 
-  `pptx verify` is intentionally different for validation failures: an invalid
-  but readable PPTX is a successful verification result with `valid: false` on
-  stdout and process exit code `4`. Operational failures (missing file, IO
-  errors, unexpected exceptions) still use the stderr error shape above.
+  `pptx verify`, `word verify`, and `excel verify` are intentionally different
+  for validation failures: an invalid but readable file is a successful
+  verification result with `valid: false` on stdout and process exit code `4`.
+  Operational failures (missing file, IO errors, unexpected exceptions) still
+  use the stderr error shape above.
 
 ## Exit codes
 
@@ -49,9 +50,9 @@ published for documentation, integration validation, and contract tests.
 
 ## Diagnostics
 
-`pptx verify` diagnostics use a unified `kind` field. SDK diagnostics map from
-OpenXml SDK `ValidationErrorType` values; Clippit-specific diagnostics use
-custom kind values.
+`pptx verify`, `word verify`, and `excel verify` diagnostics use a unified
+`kind` field. SDK diagnostics map from OpenXml SDK `ValidationErrorType`
+values; Clippit-specific diagnostics use custom kind values.
 
 Current diagnostic kinds:
 

--- a/docs/schemas/verify-result.v1.json
+++ b/docs/schemas/verify-result.v1.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://sergey-tihon.github.io/Clippit/schemas/verify-result.v1.json",
-  "title": "Clippit pptx verify result",
-  "description": "Result payload of `clippit pptx verify` written to stdout in JSON mode. Invalid presentations are reported here with exit code 4 rather than as stderr command errors.",
+  "title": "Clippit verify result",
+  "description": "Result payload of `clippit word verify`, `clippit excel verify`, or `clippit pptx verify` written to stdout in JSON mode. Invalid documents are reported here with exit code 4 rather than as stderr command errors.",
   "type": "object",
   "additionalProperties": false,
   "required": ["input", "officeVersion", "valid", "diagnostics"],

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -21,6 +21,12 @@ clippit pptx build run manifest.json --output result.pptx
 # Validate a PPTX file
 clippit pptx verify presentation.pptx
 
+# Validate a DOCX file
+clippit word verify document.docx
+
+# Validate an XLSX file
+clippit excel verify spreadsheet.xlsx
+
 # Get JSON output for scripting
 clippit pptx split presentation.pptx --format json
 ```
@@ -33,6 +39,8 @@ clippit pptx split presentation.pptx --format json
 | `pptx build init` | Scaffold a deck manifest (JSON).                                                                                                        |
 | `pptx build run`  | Assemble a `.pptx` from a deck manifest.                                                                                                |
 | `pptx verify`     | Validate a PPTX — schema, relationships, markup compatibility, and sections.                                                            |
+| `word verify`     | Validate a DOCX — schema and relationships.                                                                                             |
+| `excel verify`    | Validate an XLSX — schema and relationships.                                                                                            |
 | `version`         | Print version information.                                                                                                              |
 
 ### Common flags


### PR DESCRIPTION
## Summary

Adds \`word verify\` and \`excel verify\` commands to the Clippit CLI, bringing it to parity with the existing \`pptx verify\` command.

## What's new

- **\`word verify\`** — validate a `.docx` file
- **\`excel verify\`** — validate a `.xlsx` file
- New root command groups: \`word\` and \`excel\` (siblings of \`pptx\`)
- All three verify commands share a common payload contract (same JSON shape)
- Updated CLI documentation, README, and JSON schema docs
- Bumped CLI version to 0.2.0

## Usage

\`\`\`bash
clippit word verify document.docx
clippit excel verify spreadsheet.xlsx
clippit word verify document.docx --office-version Office2021
cat spreadsheet.xlsx | clippit excel verify - --format json
\`\`\`

## Tests

- 8 new tests for \`word verify\`
- 8 new tests for \`excel verify\`
- All existing 9 \`pptx verify\` tests still pass (no regression)