### PR TITLE
Remove SixLabors.ImageSharp.Drawing, replace with SkiaSharp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [3.5.0] - June 20, 2026
+
+- feat: replace SixLabors.ImageSharp with SkiaSharp for all image processing (#341)
+- feat: add Linux native SkiaSharp asset support (`SkiaSharp.NativeAssets.Linux.NoDependencies`) (#341)
+- fix(html): guard null `srcAttribute` in `LoadImageForTransform` to prevent `NullReferenceException` (#341)
+- fix(html): encode image before adding `ImagePart` to prevent dangling empty relationship on encode failure (#341)
+- fix(docs): update `WmlToHtmlConverter` tutorial from ImageSharp to SkiaSharp API (#341)
+- fix(docs): add `using SkiaSharp;` note in tutorial code sample (#341)
+- refactor: replace `Image.Load`/`Image.Save` with `SKBitmap.Decode`/`SKImage.Encode` across all converters and helpers (#341)
+- refactor: replace `SixLabors.Fonts` text measurement with `SKTypeface`/`SKPaint.MeasureText` in `MetricsGetter` and `PtOpenXmlUtil` (#341)
+- refactor: use safe fallback chain for `GetTextWidth` — `ArgumentException` catch now works correctly after removing blanket catch in `_getTextWidth` (#341)
+- fix(cli): use `FileMode.Create` instead of `FileMode.OpenOrCreate` in `DefaultImageHandler` to avoid corrupted image on re-encode (#341)
+- fix(cli): return `null` instead of `null!` in `CreateInlineImage` failure paths (#341)
+- fix(test): add explicit null-check with `InvalidOperationException` in `BuildTestPng` SkiaSharp encode (#341)
+- perf: wrap `SKTypeface`/`SKFont`/`SKImage` with `using` to prevent native handle leaks (#341)
+- chore(deps): remove `SixLabors.ImageSharp.Drawing` dependency (#341)
+- chore(deps): add `SkiaSharp 3.119.4` (#341)
+
 ## [3.4.7] - June 16, 2026
 
 - feat(cli): add `word to-html`, `word from-html`, and `excel to-html` commands (#338)

--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.4.0] - 2026-06-20
+
+- refactor: replace SixLabors.ImageSharp with SkiaSharp for image processing in
+  `word to-html` inline image encoding and CLI image handler (#341)
+- fix(cli): use `FileMode.Create` instead of `FileMode.OpenOrCreate` in
+  `DefaultImageHandler` to avoid corrupted images on re-encode (#341)
+- fix(cli): return `null` instead of `null!` in `CreateInlineImage` failure
+  paths when SkiaSharp encode fails (#341)
+- chore(deps): remove `SixLabors.ImageSharp.Drawing`, add `SkiaSharp 3.119.4` (#341)
+
 ## [0.3.0] - 2026-06-15
 
 - Added `word to-html` command to convert `.docx` files to HTML/CSS with

--- a/Clippit.Cli/Commands/Word/ToHtml/WordToHtmlService.cs
+++ b/Clippit.Cli/Commands/Word/ToHtml/WordToHtmlService.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Xml.Linq;
 using Clippit.Cli.Infrastructure;
 using Clippit.Word;
+using SkiaSharp;
 
 namespace Clippit.Cli.Commands.Word.ToHtml;
 
@@ -141,9 +142,10 @@ internal static class WordToHtmlService
         try
         {
             using var ms = new MemoryStream();
-            imageInfo.Image.Save(ms, imageEncoder);
-            var ba = ms.ToArray();
-            base64 = Convert.ToBase64String(ba);
+            using var image = SKImage.FromBitmap(imageInfo.Image);
+            using var data = image.Encode(imageEncoder.Value, quality: 80);
+            data.SaveTo(ms);
+            base64 = Convert.ToBase64String(ms.ToArray());
         }
         catch (System.Runtime.InteropServices.ExternalException)
         {

--- a/Clippit.Cli/Commands/Word/ToHtml/WordToHtmlService.cs
+++ b/Clippit.Cli/Commands/Word/ToHtml/WordToHtmlService.cs
@@ -144,16 +144,16 @@ internal static class WordToHtmlService
             using var ms = new MemoryStream();
             using var image = SKImage.FromBitmap(imageInfo.Image);
             if (image == null)
-                return null!;
+                return null;
             using var data = image.Encode(imageEncoder.Value, quality: 80);
             if (data == null)
-                return null!;
+                return null;
             data.SaveTo(ms);
             base64 = Convert.ToBase64String(ms.ToArray());
         }
         catch (System.Runtime.InteropServices.ExternalException)
         {
-            return null!;
+            return null;
         }
 
         var mimeType = "image/" + extension;

--- a/Clippit.Cli/Commands/Word/ToHtml/WordToHtmlService.cs
+++ b/Clippit.Cli/Commands/Word/ToHtml/WordToHtmlService.cs
@@ -143,7 +143,11 @@ internal static class WordToHtmlService
         {
             using var ms = new MemoryStream();
             using var image = SKImage.FromBitmap(imageInfo.Image);
+            if (image == null)
+                return null!;
             using var data = image.Encode(imageEncoder.Value, quality: 80);
+            if (data == null)
+                return null!;
             data.SaveTo(ms);
             base64 = Convert.ToBase64String(ms.ToArray());
         }

--- a/Clippit.Cli/ILLink.Descriptors.xml
+++ b/Clippit.Cli/ILLink.Descriptors.xml
@@ -3,8 +3,8 @@
     ILLink / NativeAOT root descriptors for Clippit.Cli.
 
     All DocumentFormat.OpenXml types (3.5.1, net10.0, IsTrimmable=true) and
-    SixLabors.ImageSharp word/HTML paths are handled by static analysis —
-    no manual roots needed for those.
+    SkiaSharp word/HTML paths are handled by static analysis — no manual roots
+    needed for those.
 
     SlideMasterPart and SlideLayoutPart are kept because OpenXml's internal
     part-loading mechanism may resolve these types via a type-keyed dictionary

--- a/Clippit.Tests/Word/DocumentAssemblerTests.cs
+++ b/Clippit.Tests/Word/DocumentAssemblerTests.cs
@@ -6,6 +6,7 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using Clippit.Word;
 using DocumentFormat.OpenXml.Packaging;
+using SkiaSharp;
 
 namespace Clippit.Tests.Word;
 
@@ -952,19 +953,12 @@ public class DocumentAssemblerTests : TestsBase
     /// <summary>Creates a minimal solid-color PNG of the given dimensions.</summary>
     private static byte[] BuildTestPng(int width, int height)
     {
-        using var newImage = new SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>(width, height);
-        newImage.ProcessPixelRows(accessor =>
-        {
-            for (var y = 0; y < accessor.Height; y++)
-            {
-                var row = accessor.GetRowSpan(y);
-                for (var x = 0; x < row.Length; x++)
-                    row[x] = new SixLabors.ImageSharp.PixelFormats.Rgba32(100, 149, 237, 255); // cornflower blue
-            }
-        });
-        using var outMs = new MemoryStream();
-        newImage.Save(outMs, new SixLabors.ImageSharp.Formats.Png.PngEncoder());
-        return outMs.ToArray();
+        using var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(new SKColor(100, 149, 237, 255)); // cornflower blue
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, quality: 80);
+        return data.ToArray();
     }
 
     /// <summary>

--- a/Clippit.Tests/Word/DocumentAssemblerTests.cs
+++ b/Clippit.Tests/Word/DocumentAssemblerTests.cs
@@ -958,6 +958,8 @@ public class DocumentAssemblerTests : TestsBase
         canvas.Clear(new SKColor(100, 149, 237, 255)); // cornflower blue
         using var image = SKImage.FromBitmap(bitmap);
         using var data = image.Encode(SKEncodedImageFormat.Png, quality: 80);
+        if (data is null)
+            throw new InvalidOperationException("SkiaSharp failed to encode test PNG.");
         return data.ToArray();
     }
 

--- a/Clippit.Tests/Word/Samples/WmlToHtmlConverterSamples.cs
+++ b/Clippit.Tests/Word/Samples/WmlToHtmlConverterSamples.cs
@@ -2,6 +2,7 @@
 using System.Xml.Linq;
 using Clippit.Word;
 using DocumentFormat.OpenXml.Packaging;
+using SkiaSharp;
 
 namespace Clippit.Tests.Word.Samples
 {
@@ -137,10 +138,18 @@ namespace Clippit.Tests.Word.Samples
                     if (imageEncoder is null)
                         return null;
                     string base64 = null;
+                    if (imageInfo.Image == null)
+                        return null;
                     try
                     {
                         using var ms = new MemoryStream();
-                        imageInfo.Image.Save(ms, imageEncoder);
+                        using var image = SKImage.FromBitmap(imageInfo.Image);
+                        if (image == null)
+                            return null;
+                        using var data = image.Encode(imageEncoder.Value, quality: 80);
+                        if (data == null)
+                            return null;
+                        data.SaveTo(ms);
                         var ba = ms.ToArray();
                         base64 = System.Convert.ToBase64String(ba);
                     }

--- a/Clippit/Html/HtmlToWmlConverterCore.cs
+++ b/Clippit/Html/HtmlToWmlConverterCore.cs
@@ -100,8 +100,7 @@ using System.Xml.Linq;
 using Clippit.Internal;
 using Clippit.Word;
 using DocumentFormat.OpenXml.Packaging;
-using SixLabors.ImageSharp.Formats.Bmp;
-using Image = SixLabors.ImageSharp.Image;
+using SkiaSharp;
 
 namespace Clippit.Html
 {
@@ -2293,7 +2292,7 @@ namespace Clippit.Html
         {
             var srcAttribute = (string)element.Attribute(XhtmlNoNamespace.src);
             byte[] ba = null;
-            Image bmp = null;
+            SKBitmap bmp = null;
 
             if (srcAttribute.StartsWith("data:"))
             {
@@ -2302,13 +2301,13 @@ namespace Clippit.Html
                 var base64 = srcAttribute.Substring(commaIndex + 1);
                 ba = Convert.FromBase64String(base64);
                 using var ms = new MemoryStream(ba);
-                bmp = Image.Load(ms);
+                bmp = SKBitmap.Decode(ms);
             }
             else
             {
                 try
                 {
-                    bmp = Image.Load(settings.BaseUriForImages + "/" + srcAttribute);
+                    bmp = SKBitmap.Decode(settings.BaseUriForImages + "/" + srcAttribute);
                 }
                 catch (DirectoryNotFoundException)
                 {
@@ -2322,10 +2321,21 @@ namespace Clippit.Html
                 {
                     return null;
                 }
+                if (bmp == null)
+                    return null;
                 using var ms = new MemoryStream();
-                bmp.Save(ms, new BmpEncoder());
+                var image2 = SKImage.FromBitmap(bmp);
+                if (image2 == null)
+                    return null;
+                using var data2 = image2.Encode(SKEncodedImageFormat.Bmp, quality: 80);
+                if (data2 == null)
+                    return null;
+                data2.SaveTo(ms);
                 ba = ms.ToArray();
             }
+
+            if (bmp == null)
+                return null;
 
             var mdp = wDoc.MainDocumentPart;
             var ipt = ImagePartType.Png;
@@ -2377,7 +2387,7 @@ namespace Clippit.Html
             XElement element,
             HtmlToWmlConverterSettings settings,
             WordprocessingDocument wDoc,
-            Image bmp,
+            SKBitmap bmp,
             string rId,
             int pictureId,
             string pictureDescription
@@ -2403,7 +2413,7 @@ namespace Clippit.Html
             XElement element,
             HtmlToWmlConverterSettings settings,
             WordprocessingDocument wDoc,
-            Image bmp,
+            SKBitmap bmp,
             string rId,
             string floatValue,
             int pictureId,
@@ -2600,13 +2610,11 @@ namespace Clippit.Html
             return new XElement(W.rPr, new XElement(W.noProof));
         }
 
-        private static SizeEmu GetImageSizeInEmus(XElement img, Image bmp)
+        private static SizeEmu GetImageSizeInEmus(XElement img, SKBitmap bmp)
         {
-            var hres = bmp.Metadata.HorizontalResolution;
-            var vres = bmp.Metadata.VerticalResolution;
-            var s = bmp.Size;
-            Emu cx = (long)(s.Width / hres * Emu.s_EmusPerInch);
-            Emu cy = (long)(s.Height / vres * Emu.s_EmusPerInch);
+            // SkiaSharp does not preserve DPI from encoded images, so default to 96.
+            Emu cx = (long)(bmp.Width / 96.0 * Emu.s_EmusPerInch);
+            Emu cy = (long)(bmp.Height / 96.0 * Emu.s_EmusPerInch);
 
             var width = img.GetProp("width");
             var height = img.GetProp("height");
@@ -2633,7 +2641,7 @@ namespace Clippit.Html
             return new SizeEmu(cx, cy);
         }
 
-        private static XElement GetImageExtent(XElement img, Image bmp)
+        private static XElement GetImageExtent(XElement img, SKBitmap bmp)
         {
             var szEmu = GetImageSizeInEmus(img, bmp);
             return new XElement(
@@ -2679,7 +2687,7 @@ namespace Clippit.Html
         private static XElement GetGraphicForImage(
             XElement element,
             string rId,
-            Image bmp,
+            SKBitmap bmp,
             int pictureId,
             string pictureDescription
         )

--- a/Clippit/Html/HtmlToWmlConverterCore.cs
+++ b/Clippit/Html/HtmlToWmlConverterCore.cs
@@ -2328,19 +2328,25 @@ namespace Clippit.Html
             if (bmp == null)
                 return null;
 
-            var mdp = wDoc.MainDocumentPart;
-            var newPart = mdp.AddImagePart(ImagePartType.Png);
-            var rId = mdp.GetIdOfPart(newPart);
-            using (var partStream = newPart.GetStream(FileMode.Create, FileAccess.ReadWrite))
+            // Encode first; only add the image part to the package if encoding succeeds.
+            // This avoids leaving a dangling empty relationship on encode failure.
+            SKData encodedData;
             using (var image = SKImage.FromBitmap(bmp))
             {
                 if (image == null)
                     return null;
-                using var data = image.Encode(SKEncodedImageFormat.Png, quality: 80);
+                var data = image.Encode(SKEncodedImageFormat.Png, quality: 80);
                 if (data == null)
                     return null;
-                data.SaveTo(partStream);
+                encodedData = data;
             }
+
+            var mdp = wDoc.MainDocumentPart;
+            var newPart = mdp.AddImagePart(ImagePartType.Png);
+            var rId = mdp.GetIdOfPart(newPart);
+            using (encodedData)
+            using (var partStream = newPart.GetStream(FileMode.Create, FileAccess.ReadWrite))
+                encodedData.SaveTo(partStream);
 
             var pid = wDoc.Annotation<PictureId>();
             if (pid == null)

--- a/Clippit/Html/HtmlToWmlConverterCore.cs
+++ b/Clippit/Html/HtmlToWmlConverterCore.cs
@@ -2284,30 +2284,22 @@ namespace Clippit.Html
             }
         }
 
-        private static XElement TransformImageToWml(
-            XElement element,
-            HtmlToWmlConverterSettings settings,
-            WordprocessingDocument wDoc
-        )
+        private static SKBitmap? LoadImageForTransform(string srcAttribute, HtmlToWmlConverterSettings settings)
         {
-            var srcAttribute = (string)element.Attribute(XhtmlNoNamespace.src);
-            byte[] ba = null;
-            SKBitmap bmp = null;
-
             if (srcAttribute.StartsWith("data:"))
             {
                 var semiIndex = srcAttribute.IndexOf(';');
                 var commaIndex = srcAttribute.IndexOf(',', semiIndex);
                 var base64 = srcAttribute.Substring(commaIndex + 1);
-                ba = Convert.FromBase64String(base64);
-                using var ms = new MemoryStream(ba);
-                bmp = SKBitmap.Decode(ms);
+                var rawBytes = Convert.FromBase64String(base64);
+                using var ms = new MemoryStream(rawBytes);
+                return SKBitmap.Decode(ms);
             }
             else
             {
                 try
                 {
-                    bmp = SKBitmap.Decode(settings.BaseUriForImages + "/" + srcAttribute);
+                    return SKBitmap.Decode(settings.BaseUriForImages + "/" + srcAttribute);
                 }
                 catch (DirectoryNotFoundException)
                 {
@@ -2321,28 +2313,34 @@ namespace Clippit.Html
                 {
                     return null;
                 }
-                if (bmp == null)
-                    return null;
-                using var ms = new MemoryStream();
-                var image2 = SKImage.FromBitmap(bmp);
-                if (image2 == null)
-                    return null;
-                using var data2 = image2.Encode(SKEncodedImageFormat.Bmp, quality: 80);
-                if (data2 == null)
-                    return null;
-                data2.SaveTo(ms);
-                ba = ms.ToArray();
             }
+        }
+
+        private static XElement TransformImageToWml(
+            XElement element,
+            HtmlToWmlConverterSettings settings,
+            WordprocessingDocument wDoc
+        )
+        {
+            var srcAttribute = (string)element.Attribute(XhtmlNoNamespace.src);
+            using var bmp = LoadImageForTransform(srcAttribute, settings);
 
             if (bmp == null)
                 return null;
 
             var mdp = wDoc.MainDocumentPart;
-            var ipt = ImagePartType.Png;
-            var newPart = mdp.AddImagePart(ipt);
+            var newPart = mdp.AddImagePart(ImagePartType.Png);
             var rId = mdp.GetIdOfPart(newPart);
-            using (var s = newPart.GetStream(FileMode.Create, FileAccess.ReadWrite))
-                s.Write(ba, 0, ba.GetUpperBound(0) + 1);
+            using (var partStream = newPart.GetStream(FileMode.Create, FileAccess.ReadWrite))
+            using (var image = SKImage.FromBitmap(bmp))
+            {
+                if (image == null)
+                    return null;
+                using var data = image.Encode(SKEncodedImageFormat.Png, quality: 80);
+                if (data == null)
+                    return null;
+                data.SaveTo(partStream);
+            }
 
             var pid = wDoc.Annotation<PictureId>();
             if (pid == null)

--- a/Clippit/Html/HtmlToWmlConverterCore.cs
+++ b/Clippit/Html/HtmlToWmlConverterCore.cs
@@ -2286,6 +2286,8 @@ namespace Clippit.Html
 
         private static SKBitmap? LoadImageForTransform(string srcAttribute, HtmlToWmlConverterSettings settings)
         {
+            if (string.IsNullOrEmpty(srcAttribute))
+                return null;
             if (srcAttribute.StartsWith("data:"))
             {
                 var semiIndex = srcAttribute.IndexOf(';');

--- a/Clippit/MetricsGetter.cs
+++ b/Clippit/MetricsGetter.cs
@@ -74,13 +74,7 @@ public class MetricsGetter
         }
     }
 
-    private static int _getTextWidth(
-        SKTypeface typeface,
-        SKFontStyleWeight weight,
-        SKFontStyleSlant slant,
-        decimal sz,
-        string text
-    )
+    private static int _getTextWidth(SKTypeface typeface, decimal sz, string text)
     {
         try
         {
@@ -96,38 +90,49 @@ public class MetricsGetter
         }
     }
 
-    public static int GetTextWidth(
-        SKTypeface typeface,
-        SKFontStyleWeight weight,
-        SKFontStyleSlant slant,
-        decimal sz,
-        string text
-    )
+    public static int GetTextWidth(SKTypeface typeface, decimal sz, string text)
     {
         try
         {
-            return _getTextWidth(typeface, weight, slant, sz, text);
+            return _getTextWidth(typeface, sz, text);
         }
         catch (ArgumentException)
         {
             try
             {
-                return _getTextWidth(typeface, SKFontStyleWeight.Normal, SKFontStyleSlant.Upright, sz, text);
+                // Some fonts don't support the requested style (e.g. no italic variant).
+                // Create a fallback typeface with normal weight and upright slant.
+                using var normal = SKTypeface.FromFamilyName(
+                    typeface.FamilyName,
+                    SKFontStyleWeight.Normal,
+                    SKFontStyleWidth.Normal,
+                    SKFontStyleSlant.Upright
+                );
+                if (normal == null)
+                    return 0;
+                return _getTextWidth(normal, sz, text);
             }
             catch (ArgumentException)
             {
                 try
                 {
-                    return _getTextWidth(typeface, SKFontStyleWeight.Bold, SKFontStyleSlant.Upright, sz, text);
+                    using var bold = SKTypeface.FromFamilyName(
+                        typeface.FamilyName,
+                        SKFontStyleWeight.Bold,
+                        SKFontStyleWidth.Normal,
+                        SKFontStyleSlant.Upright
+                    );
+                    if (bold == null)
+                        return 0;
+                    return _getTextWidth(bold, sz, text);
                 }
                 catch (ArgumentException)
                 {
                     // if both regular and bold fail, then get metrics for Times New Roman
-                    // use the original FontStyle (in fs)
-                    var fallback = SKTypeface.FromFamilyName("Times New Roman");
+                    using var fallback = SKTypeface.FromFamilyName("Times New Roman");
                     if (fallback == null)
                         return 0;
-                    return _getTextWidth(fallback, weight, slant, sz, text);
+                    return _getTextWidth(fallback, sz, text);
                 }
             }
         }

--- a/Clippit/MetricsGetter.cs
+++ b/Clippit/MetricsGetter.cs
@@ -11,7 +11,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Experimental;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
-using SixLabors.Fonts;
+using SkiaSharp;
 
 namespace Clippit;
 
@@ -74,16 +74,21 @@ public class MetricsGetter
         }
     }
 
-    private static int _getTextWidth(FontFamily ff, FontStyle fs, decimal sz, string text)
+    private static int _getTextWidth(
+        SKTypeface typeface,
+        SKFontStyleWeight weight,
+        SKFontStyleSlant slant,
+        decimal sz,
+        string text
+    )
     {
         try
         {
-            var f = ff.CreateFont((float)sz / 2f, fs);
-            var box = TextMeasurer.MeasureBounds(text, new TextOptions(f));
-            return (int)box.Width;
-            // var proposedSize = new Size(int.MaxValue, int.MaxValue);
-            // var sf = Graphics.Value.MeasureString(text, f, proposedSize);
-            // return (int) sf.Width;
+            var fontSize = (float)sz / 2f;
+            using var font = new SKFont(typeface, fontSize, 1, 0);
+            using var paint = new SKPaint(font) { SubpixelText = true, IsAntialias = true };
+            var width = paint.MeasureText(text);
+            return (int)width;
         }
         catch
         {
@@ -91,32 +96,38 @@ public class MetricsGetter
         }
     }
 
-    public static int GetTextWidth(FontFamily ff, FontStyle fs, decimal sz, string text)
+    public static int GetTextWidth(
+        SKTypeface typeface,
+        SKFontStyleWeight weight,
+        SKFontStyleSlant slant,
+        decimal sz,
+        string text
+    )
     {
         try
         {
-            return _getTextWidth(ff, fs, sz, text);
+            return _getTextWidth(typeface, weight, slant, sz, text);
         }
         catch (ArgumentException)
         {
             try
             {
-                return _getTextWidth(ff, FontStyle.Regular, sz, text);
+                return _getTextWidth(typeface, SKFontStyleWeight.Normal, SKFontStyleSlant.Upright, sz, text);
             }
             catch (ArgumentException)
             {
                 try
                 {
-                    return _getTextWidth(ff, FontStyle.Bold, sz, text);
+                    return _getTextWidth(typeface, SKFontStyleWeight.Bold, SKFontStyleSlant.Upright, sz, text);
                 }
                 catch (ArgumentException)
                 {
                     // if both regular and bold fail, then get metrics for Times New Roman
                     // use the original FontStyle (in fs)
-
-                    //var ff2 = new FontFamily("Times New Roman");
-                    SystemFonts.Collection.TryGet("Times New Roman", out var ff2); // TODO: test this
-                    return _getTextWidth(ff2, fs, sz, text);
+                    var fallback = SKTypeface.FromFamilyName("Times New Roman");
+                    if (fallback == null)
+                        return 0;
+                    return _getTextWidth(fallback, weight, slant, sz, text);
                 }
             }
         }

--- a/Clippit/MetricsGetter.cs
+++ b/Clippit/MetricsGetter.cs
@@ -76,21 +76,27 @@ public class MetricsGetter
 
     private static int _getTextWidth(SKTypeface typeface, decimal sz, string text)
     {
+        var fontSize = (float)sz / 2f;
+        using var font = new SKFont(typeface, fontSize, 1, 0);
+        using var paint = new SKPaint(font) { SubpixelText = true, IsAntialias = true };
+        var width = paint.MeasureText(text);
+        return (int)width;
+    }
+
+    public static int GetTextWidth(SKTypeface typeface, decimal sz, string text)
+    {
         try
         {
-            var fontSize = (float)sz / 2f;
-            using var font = new SKFont(typeface, fontSize, 1, 0);
-            using var paint = new SKPaint(font) { SubpixelText = true, IsAntialias = true };
-            var width = paint.MeasureText(text);
-            return (int)width;
+            return _getTextWidthWithFallback(typeface, sz, text);
         }
-        catch
+        catch (OverflowException)
         {
+            // This happened on Azure but interestingly enough not while testing locally.
             return 0;
         }
     }
 
-    public static int GetTextWidth(SKTypeface typeface, decimal sz, string text)
+    private static int _getTextWidthWithFallback(SKTypeface typeface, decimal sz, string text)
     {
         try
         {
@@ -135,11 +141,6 @@ public class MetricsGetter
                     return _getTextWidth(fallback, sz, text);
                 }
             }
-        }
-        catch (OverflowException)
-        {
-            // This happened on Azure but interestingly enough not while testing locally.
-            return 0;
         }
     }
 

--- a/Clippit/OxPtHelpers.cs
+++ b/Clippit/OxPtHelpers.cs
@@ -12,11 +12,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Wordprocessing;
-using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.Formats.Bmp;
-using SixLabors.ImageSharp.Formats.Gif;
-using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.Formats.Png;
+using SkiaSharp;
 
 namespace Clippit
 {
@@ -343,27 +339,25 @@ AAsACwDBAgAAbCwAAAAA";
 
     public static class ImageHelper
     {
-        public static IImageEncoder GetEncoder(string extension, out string newExtension)
+        public static SKEncodedImageFormat? GetEncoder(string extension, out string newExtension)
         {
             newExtension = extension;
             switch (extension)
             {
                 case "png":
-                    return new PngEncoder();
+                    return SKEncodedImageFormat.Png;
                 case "gif":
-                    return new GifEncoder();
+                    return SKEncodedImageFormat.Gif;
                 case "bmp":
-                    return new BmpEncoder();
+                    return SKEncodedImageFormat.Bmp;
                 case "jpeg":
-                    return new JpegEncoder();
+                    return SKEncodedImageFormat.Jpeg;
                 case "tiff":
                     // Convert tiff to gif.
                     newExtension = "gif";
-                    return new GifEncoder();
+                    return SKEncodedImageFormat.Gif;
                 case "x-wmf":
                     // TODO: What to do with Wmf?
-                    //newExtension = "wmf";
-                    //imageEncoder = ImageFormat.Wmf;
                     break;
             }
 
@@ -385,10 +379,18 @@ AAsACwDBAgAAbCwAAAAA";
                 return null;
 
             var imageFileName = imageDirectoryName + "/image" + imageCounter + "." + extension;
+            if (imageInfo.Image == null)
+                return null;
             try
             {
                 using var fs = File.Open(imageFileName, FileMode.OpenOrCreate, FileAccess.Write);
-                imageInfo.Image.Save(fs, imageEncoder);
+                using var image = SKImage.FromBitmap(imageInfo.Image);
+                if (image == null)
+                    return null;
+                using var data = image.Encode(imageEncoder.Value, quality: 80);
+                if (data == null)
+                    return null;
+                data.SaveTo(fs);
             }
             catch (System.Runtime.InteropServices.ExternalException)
             {

--- a/Clippit/OxPtHelpers.cs
+++ b/Clippit/OxPtHelpers.cs
@@ -347,15 +347,16 @@ AAsACwDBAgAAbCwAAAAA";
                 case "png":
                     return SKEncodedImageFormat.Png;
                 case "gif":
-                    return SKEncodedImageFormat.Gif;
                 case "bmp":
-                    return SKEncodedImageFormat.Bmp;
+                    // SKImage.Encode does not support GIF or BMP. Preserve the image by converting to PNG.
+                    newExtension = "png";
+                    return SKEncodedImageFormat.Png;
                 case "jpeg":
                     return SKEncodedImageFormat.Jpeg;
                 case "tiff":
-                    // Convert tiff to gif.
-                    newExtension = "gif";
-                    return SKEncodedImageFormat.Gif;
+                    // Convert TIFF to PNG because SkiaSharp cannot encode GIF in this API.
+                    newExtension = "png";
+                    return SKEncodedImageFormat.Png;
                 case "x-wmf":
                     // TODO: What to do with Wmf?
                     break;

--- a/Clippit/OxPtHelpers.cs
+++ b/Clippit/OxPtHelpers.cs
@@ -384,7 +384,7 @@ AAsACwDBAgAAbCwAAAAA";
                 return null;
             try
             {
-                using var fs = File.Open(imageFileName, FileMode.OpenOrCreate, FileAccess.Write);
+                using var fs = File.Open(imageFileName, FileMode.Create, FileAccess.Write);
                 using var image = SKImage.FromBitmap(imageInfo.Image);
                 if (image == null)
                     return null;

--- a/Clippit/PtOpenXmlUtil.cs
+++ b/Clippit/PtOpenXmlUtil.cs
@@ -632,27 +632,22 @@ namespace Clippit
             if (!KnownFamilies.Contains(fontName))
                 return (0, tabLength);
 
-            // in theory, all unknown fonts are found by the above test, but if not...
-            using var typeface = SKTypeface.FromFamilyName(
-                fontName,
-                SKFontStyleWeight.Normal,
-                SKFontStyleWidth.Normal,
-                SKFontStyleSlant.Upright
-            );
-            if (typeface == null)
-            {
-                UnknownFonts.Add(fontName);
-                return (0, tabLength);
-            }
-
-            SKFontStyleWeight weight = SKFontStyleWeight.Normal;
-            SKFontStyleSlant slant = SKFontStyleSlant.Upright;
+            var weight = SKFontStyleWeight.Normal;
+            var slant = SKFontStyleSlant.Upright;
             var bold = GetBoolProp(rPr, W.b) || GetBoolProp(rPr, W.bCs);
             var italic = GetBoolProp(rPr, W.i) || GetBoolProp(rPr, W.iCs);
             if (bold)
                 weight = SKFontStyleWeight.Bold;
             if (italic)
                 slant = SKFontStyleSlant.Italic;
+
+            // in theory, all unknown fonts are found by the above test, but if not...
+            using var typeface = SKTypeface.FromFamilyName(fontName, weight, SKFontStyleWidth.Normal, slant);
+            if (typeface == null)
+            {
+                UnknownFonts.Add(fontName);
+                return (0, tabLength);
+            }
 
             // Appended blank as a quick fix to accommodate &nbsp; that will get
             // appended to some layout-critical runs such as list item numbers.

--- a/Clippit/PtOpenXmlUtil.cs
+++ b/Clippit/PtOpenXmlUtil.cs
@@ -11,7 +11,7 @@ using System.Xml.Linq;
 using Clippit.Internal;
 using Clippit.Word;
 using DocumentFormat.OpenXml.Packaging;
-using SixLabors.Fonts;
+using SkiaSharp;
 
 // ReSharper disable InconsistentNaming
 
@@ -607,9 +607,7 @@ namespace Clippit
         {
             if (KnownFamilies == null)
             {
-                KnownFamilies = new HashSet<string>();
-                foreach (var fam in SystemFonts.Families)
-                    KnownFamilies.Add(fam.Name);
+                KnownFamilies = new HashSet<string>(SKFontManager.Default.FontFamilies);
             }
 
             var tabLength = r.DescendantsTrimmed(W.txbxContent)
@@ -635,21 +633,21 @@ namespace Clippit
                 return (0, tabLength);
 
             // in theory, all unknown fonts are found by the above test, but if not...
-            if (!SystemFonts.Collection.TryGet(fontName, out var ff))
+            var typeface = SKTypeface.FromFamilyName(fontName);
+            if (typeface == null)
             {
                 UnknownFonts.Add(fontName);
                 return (0, tabLength);
             }
 
-            var fs = FontStyle.Regular;
+            SKFontStyleWeight weight = SKFontStyleWeight.Normal;
+            SKFontStyleSlant slant = SKFontStyleSlant.Upright;
             var bold = GetBoolProp(rPr, W.b) || GetBoolProp(rPr, W.bCs);
             var italic = GetBoolProp(rPr, W.i) || GetBoolProp(rPr, W.iCs);
-            if (bold && !italic)
-                fs = FontStyle.Bold;
-            if (italic && !bold)
-                fs = FontStyle.Italic;
-            if (bold && italic)
-                fs = FontStyle.Bold | FontStyle.Italic;
+            if (bold)
+                weight = SKFontStyleWeight.Bold;
+            if (italic)
+                slant = SKFontStyleSlant.Italic;
 
             // Appended blank as a quick fix to accommodate &nbsp; that will get
             // appended to some layout-critical runs such as list item numbers.
@@ -680,7 +678,7 @@ namespace Clippit
                 runText = sb.ToString();
             }
 
-            var width = (double)MetricsGetter.GetTextWidth(ff, fs, sz, runText) / (double)multiplier;
+            var width = (double)MetricsGetter.GetTextWidth(typeface, weight, slant, sz, runText) / (double)multiplier;
             return (width, tabLength);
         }
 

--- a/Clippit/PtOpenXmlUtil.cs
+++ b/Clippit/PtOpenXmlUtil.cs
@@ -633,7 +633,12 @@ namespace Clippit
                 return (0, tabLength);
 
             // in theory, all unknown fonts are found by the above test, but if not...
-            var typeface = SKTypeface.FromFamilyName(fontName);
+            using var typeface = SKTypeface.FromFamilyName(
+                fontName,
+                SKFontStyleWeight.Normal,
+                SKFontStyleWidth.Normal,
+                SKFontStyleSlant.Upright
+            );
             if (typeface == null)
             {
                 UnknownFonts.Add(fontName);
@@ -678,7 +683,7 @@ namespace Clippit
                 runText = sb.ToString();
             }
 
-            var width = (double)MetricsGetter.GetTextWidth(typeface, weight, slant, sz, runText) / (double)multiplier;
+            var width = (double)MetricsGetter.GetTextWidth(typeface, sz, runText) / (double)multiplier;
             return (width, tabLength);
         }
 

--- a/Clippit/Word/Assembler/HtmlConverter.cs
+++ b/Clippit/Word/Assembler/HtmlConverter.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Clippit.Html;
 using Clippit.Internal;
 using DocumentFormat.OpenXml.Packaging;
-using SixLabors.ImageSharp;
 using NextExpected = Clippit.Html.HtmlToWmlConverterCore.NextExpected;
 
 namespace Clippit.Word.Assembler

--- a/Clippit/Word/DocumentAssembler.cs
+++ b/Clippit/Word/DocumentAssembler.cs
@@ -1165,6 +1165,11 @@ namespace Clippit.Word
                     // access the saved image and get the dimensions
                     using var savedStream = ip.GetStream(FileMode.Open);
                     using var image = SKBitmap.Decode(savedStream);
+                    if (image is null)
+                    {
+                        return element.CreateContextErrorMessage("Image: Invalid image data", templateError);
+                    }
+
                     // one inch is 914400 EMUs
                     // 96dpi where dot is pixel
                     var pixelInEMU = 914400 / 96;

--- a/Clippit/Word/DocumentAssembler.cs
+++ b/Clippit/Word/DocumentAssembler.cs
@@ -11,7 +11,7 @@ using Clippit.Word.Assembler;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
-using SixLabors.ImageSharp;
+using SkiaSharp;
 using Path = System.IO.Path;
 
 namespace Clippit.Word
@@ -1164,7 +1164,7 @@ namespace Clippit.Word
 
                     // access the saved image and get the dimensions
                     using var savedStream = ip.GetStream(FileMode.Open);
-                    using var image = Image.Load(savedStream);
+                    using var image = SKBitmap.Decode(savedStream);
                     // one inch is 914400 EMUs
                     // 96dpi where dot is pixel
                     var pixelInEMU = 914400 / 96;

--- a/Clippit/Word/WmlToHtmlConverter.cs
+++ b/Clippit/Word/WmlToHtmlConverter.cs
@@ -3550,7 +3550,7 @@ namespace Clippit.Word
                 return null;
 
             using var partStream = imagePart.GetStream();
-            var image = SKBitmap.Decode(partStream);
+            using var image = SKBitmap.Decode(partStream);
             if (image == null)
                 return null;
             if (extentCx != null && extentCy != null)
@@ -3627,7 +3627,7 @@ namespace Clippit.Word
                 using var partStream = imagePart.GetStream();
                 try
                 {
-                    var bitmap = SKBitmap.Decode(partStream);
+                    using var bitmap = SKBitmap.Decode(partStream);
                     var imageInfo = new ImageInfo
                     {
                         Image = bitmap,

--- a/Clippit/Word/WmlToHtmlConverter.cs
+++ b/Clippit/Word/WmlToHtmlConverter.cs
@@ -3550,10 +3550,7 @@ namespace Clippit.Word
                 return null;
 
             using var partStream = imagePart.GetStream();
-            using var memStream = new MemoryStream();
-            partStream.CopyTo(memStream);
-            var imageBytes = memStream.ToArray();
-            var image = SKBitmap.Decode(imageBytes);
+            var image = SKBitmap.Decode(partStream);
             if (image == null)
                 return null;
             if (extentCx != null && extentCy != null)

--- a/Clippit/Word/WmlToHtmlConverter.cs
+++ b/Clippit/Word/WmlToHtmlConverter.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
-using Image = SixLabors.ImageSharp.Image;
+using SkiaSharp;
 
 // 200e lrm - LTR
 // 200f rlm - RTL
@@ -106,7 +106,7 @@ namespace Clippit.Word
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     public class ImageInfo
     {
-        public Image Image;
+        public SKBitmap Image;
         public XAttribute ImgStyleAttribute;
         public string ContentType;
         public XElement DrawingElement;
@@ -3550,7 +3550,12 @@ namespace Clippit.Word
                 return null;
 
             using var partStream = imagePart.GetStream();
-            using var image = Image.Load(partStream);
+            using var memStream = new MemoryStream();
+            partStream.CopyTo(memStream);
+            var imageBytes = memStream.ToArray();
+            var image = SKBitmap.Decode(imageBytes);
+            if (image == null)
+                return null;
             if (extentCx != null && extentCy != null)
             {
                 var imageInfo = new ImageInfo()
@@ -3625,7 +3630,7 @@ namespace Clippit.Word
                 using var partStream = imagePart.GetStream();
                 try
                 {
-                    using var bitmap = Image.Load(partStream);
+                    var bitmap = SKBitmap.Decode(partStream);
                     var imageInfo = new ImageInfo
                     {
                         Image = bitmap,

--- a/Clippit/Word/WmlToHtmlConverter.cs
+++ b/Clippit/Word/WmlToHtmlConverter.cs
@@ -3628,6 +3628,9 @@ namespace Clippit.Word
                 try
                 {
                     using var bitmap = SKBitmap.Decode(partStream);
+                    if (bitmap == null)
+                        return null;
+
                     var imageInfo = new ImageInfo
                     {
                         Image = bitmap,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,13 @@
   <ItemGroup Condition="'$(IsCliProject)' != 'true'">
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
+    <!-- SkiaSharp's net10.0 TFM only includes native assets for macOS and Win32.
+         Linux native assets live in a separate package that must be added explicitly. -->
+    <PackageReference
+      Include="SkiaSharp.NativeAssets.Linux.NoDependencies"
+      Version="3.119.4"
+      Condition="$([MSBuild]::IsOSPlatform('Linux'))"
+    />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
        Adding them directly would cause duplicate/conflicting resolution. -->
   <ItemGroup Condition="'$(IsCliProject)' != 'true'">
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
+    <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,12 +20,10 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
     <!-- SkiaSharp's net10.0 TFM only includes native assets for macOS and Win32.
-         Linux native assets live in a separate package that must be added explicitly. -->
-    <PackageReference
-      Include="SkiaSharp.NativeAssets.Linux.NoDependencies"
-      Version="3.119.4"
-      Condition="$([MSBuild]::IsOSPlatform('Linux'))"
-    />
+         Linux native assets live in a separate package that must be added unconditionally.
+         NuGet's RID resolution ensures they only deploy on Linux targets.
+         See https://github.com/mono/SkiaSharp/issues/3329 -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/docs/tutorials/word/WmlToHtmlConverter.md
+++ b/docs/tutorials/word/WmlToHtmlConverter.md
@@ -84,6 +84,11 @@ var settings = new WmlToHtmlConverterSettings
         );
         return imgElement;
     }
+    ```
+    > [!NOTE]
+    > The `ImageHandler` callback uses SkiaSharp types (`SKImage`, `SKEncodedImageFormat`).
+    > Add `using SkiaSharp;` at the top of your file to use them.
+
 };
 
 var html = WmlToHtmlConverter.ConvertToHtml(doc, settings);

--- a/docs/tutorials/word/WmlToHtmlConverter.md
+++ b/docs/tutorials/word/WmlToHtmlConverter.md
@@ -49,7 +49,7 @@ The `ImageHandler` callback receives an `ImageInfo` object for each image in the
 
 | Field | Type | Description |
 |---|---|---|
-| `Image` | `SixLabors.ImageSharp.Image` | The decoded image |
+| `Image` | `SkiaSharp.SKBitmap` | The decoded image |
 | `ImgStyleAttribute` | `XAttribute` | The computed `style` attribute (width/height) |
 | `ContentType` | `string` | The image MIME type |
 | `DrawingElement` | `XElement` | The source OpenXml drawing element |
@@ -70,7 +70,9 @@ var settings = new WmlToHtmlConverterSettings
     {
         // Convert images to inline base64 data URIs
         using var stream = new MemoryStream();
-        imageInfo.Image.SaveAsPng(stream);
+        using var image = SKImage.FromBitmap(imageInfo.Image);
+        using var data = image.Encode(SKEncodedImageFormat.Png, quality: 80);
+        data.SaveTo(stream);
         var base64 = Convert.ToBase64String(stream.ToArray());
         var imgElement = new XElement(
             Xhtml.img,

--- a/docs/tutorials/word/WmlToHtmlConverter.md
+++ b/docs/tutorials/word/WmlToHtmlConverter.md
@@ -71,7 +71,9 @@ var settings = new WmlToHtmlConverterSettings
         // Convert images to inline base64 data URIs
         using var stream = new MemoryStream();
         using var image = SKImage.FromBitmap(imageInfo.Image);
+        if (image == null) return null;
         using var data = image.Encode(SKEncodedImageFormat.Png, quality: 80);
+        if (data == null) return null;
         data.SaveTo(stream);
         var base64 = Convert.ToBase64String(stream.ToArray());
         var imgElement = new XElement(


### PR DESCRIPTION
## Summary

Removes the unused `SixLabors.ImageSharp.Drawing` dependency and replaces all existing ImageSharp (`SixLabors.ImageSharp`) and SixLabors.Fonts usages with **SkiaSharp**.

## Changes

- **`Directory.Build.props`**: `SixLabors.ImageSharp.Drawing` → `SkiaSharp 3.119.4`
- **`OxPtHelpers.cs`**: `IImageEncoder` → `SKEncodedImageFormat?`, save via `SKImage.FromBitmap + Encode + SaveTo`
- **`WmlToHtmlConverter.cs`**: `ImageInfo.Image` type → `SKBitmap`; `Image.Load` → `SKBitmap.Decode`
- **`HtmlToWmlConverterCore.cs`**: `Image.Load` → `SKBitmap.Decode`, `BmpEncoder` → `Encode(SKEncodedImageFormat.Bmp)`
- **`DocumentAssembler.cs`**: `Image.Load` → `SKBitmap.Decode`
- **`MetricsGetter.cs`**: `FontFamily/TextMeasurer` → `SKTypeface/SKPaint.MeasureText`
- **`PtOpenXmlUtil.cs`**: `SystemFonts` → `SKFontManager.Default`, `FontStyle` → `SKFontStyleWeight/Slant`
- **`WordToHtmlService.cs`** (CLI): image save via `SKImage.FromBitmap + Encode`
- **`HtmlConverter.cs`** (Assembler): removed unused `SixLabors.ImageSharp` using
- **Test files**: `BuildTestPng` → `SKBitmap + SKCanvas`; null guards for image handlers

## Verification

- ✅ Build succeeds (`dotnet build`)
- ✅ All 1989 tests pass
- ✅ CSharpier formatting clean
- ✅ NativeAOT smoke test passes (publishes and runs `version`, `pptx build`, `pptx split`)
- ✅ No trim/ILLink warnings during AOT publish
- ✅ Native `libSkiaSharp.dylib` correctly bundled in AOT output
- ✅ `dotnet publish -r linux-x64 -p:NativeAot=true` compiles (link step requires linux toolchain, expected on macOS)