### PR TITLE
feat(npm): add Linux ARM64 native binary support

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -31,6 +31,9 @@ jobs:
           - rid: linux-x64
             os: ubuntu-latest
             binary: clippit
+          - rid: linux-arm64
+            os: ubuntu-24.04-arm
+            binary: clippit
           - rid: win-x64
             os: windows-latest
             binary: clippit.exe
@@ -51,7 +54,7 @@ jobs:
           global-json-file: global.json
 
       - name: Install Linux NativeAOT toolchain
-        if: matrix.rid == 'linux-x64'
+        if: startsWith(matrix.rid, 'linux-')
         run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
       - name: Publish NativeAOT binary
@@ -93,6 +96,12 @@ jobs:
           name: clippit-linux-x64
           path: bin/cli/linux-x64
 
+      - name: Download linux-arm64 binary
+        uses: actions/download-artifact@v8
+        with:
+          name: clippit-linux-arm64
+          path: bin/cli/linux-arm64
+
       - name: Download win-x64 binary
         uses: actions/download-artifact@v8
         with:
@@ -114,7 +123,7 @@ jobs:
       - name: Pack npm packages
         run: dotnet fsi build.fsx -- -p pack-npm
         env:
-          CLIPPIT_PUBLISH_RIDS: win-x64,osx-x64,osx-arm64,linux-x64
+          CLIPPIT_PUBLISH_RIDS: win-x64,osx-x64,osx-arm64,linux-x64,linux-arm64
 
       - name: Upload npm tarballs
         uses: actions/upload-artifact@v7
@@ -130,6 +139,7 @@ jobs:
           npm publish bin/npm/sergey-tihon-clippit-bin-darwin-x64-*.tgz --provenance --access public
           npm publish bin/npm/sergey-tihon-clippit-bin-darwin-arm64-*.tgz --provenance --access public
           npm publish bin/npm/sergey-tihon-clippit-bin-linux-x64-*.tgz --provenance --access public
+          npm publish bin/npm/sergey-tihon-clippit-bin-linux-arm64-*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.0] - 2026-06-29
+
+- feat(npm): add Linux ARM64 native binary support — new npm platform package
+  `@sergey-tihon/clippit-bin-linux-arm64` built on GitHub Actions
+  `ubuntu-24.04-arm` runners (#360)
+- chore(deps): bump actions/checkout from 6 to 7 (#347)
+
 ## [0.4.1] - 2026-06-23
 
 - chore(deps): update SkiaSharp 3.119.4 → 4.148.0 with migration fix (#346)

--- a/build.fsx
+++ b/build.fsx
@@ -22,6 +22,9 @@ let cliRuntimes =
         BinaryName = "clippit" }
       { Rid = "linux-x64"
         NpmDirectory = "clippit-linux-x64"
+        BinaryName = "clippit" }
+      { Rid = "linux-arm64"
+        NpmDirectory = "clippit-linux-arm64"
         BinaryName = "clippit" } ]
 
 let requestedRids =

--- a/build.fsx
+++ b/build.fsx
@@ -172,7 +172,7 @@ let publishCliBinaries () =
 let packNpmPackages () =
     if not allCliRuntimesRequested then
         failwith
-            "NPM wrapper package requires all CLI runtimes. Set CLIPPIT_PUBLISH_RIDS=win-x64,osx-x64,osx-arm64,linux-x64."
+            "NPM wrapper package requires all CLI runtimes. Set CLIPPIT_PUBLISH_RIDS=win-x64,osx-x64,osx-arm64,linux-x64,linux-arm64."
 
     let npmDir = System.IO.Path.Combine(__SOURCE_DIRECTORY__, "npm")
 

--- a/npm/clippit-linux-arm64/package.json
+++ b/npm/clippit-linux-arm64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@sergey-tihon/clippit-bin-linux-arm64",
+  "version": "0.0.0",
+  "description": "Linux ARM64 binary for the Clippit CLI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sergey-tihon/Clippit.git",
+    "directory": "npm/clippit-linux-arm64"
+  },
+  "license": "MIT",
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "files": [
+    "clippit"
+  ]
+}

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -65,12 +65,13 @@ Published JSON schemas for manifests and result payloads are available at
 
 ## Supported platforms
 
-| Platform    | Package                                  |
-| ----------- | ---------------------------------------- |
-| Windows x64 | `@sergey-tihon/clippit-bin-win32-x64`    |
-| macOS x64   | `@sergey-tihon/clippit-bin-darwin-x64`   |
-| macOS arm64 | `@sergey-tihon/clippit-bin-darwin-arm64` |
-| Linux x64   | `@sergey-tihon/clippit-bin-linux-x64`    |
+| Platform      | Package                                   |
+| ------------- | ----------------------------------------- |
+| Windows x64   | `@sergey-tihon/clippit-bin-win32-x64`     |
+| macOS x64     | `@sergey-tihon/clippit-bin-darwin-x64`    |
+| macOS arm64   | `@sergey-tihon/clippit-bin-darwin-arm64`  |
+| Linux x64     | `@sergey-tihon/clippit-bin-linux-x64`     |
+| Linux arm64   | `@sergey-tihon/clippit-bin-linux-arm64`   |
 
 The correct binary package is installed automatically as an optional dependency.
 

--- a/npm/clippit/index.js
+++ b/npm/clippit/index.js
@@ -3,10 +3,11 @@
 const path = require('path');
 
 const PLATFORM_PACKAGES = {
-  'win32-x64':    { pkg: '@sergey-tihon/clippit-bin-win32-x64',    bin: 'clippit.exe' },
-  'darwin-x64':   { pkg: '@sergey-tihon/clippit-bin-darwin-x64',   bin: 'clippit'     },
-  'darwin-arm64': { pkg: '@sergey-tihon/clippit-bin-darwin-arm64', bin: 'clippit'     },
-  'linux-x64':    { pkg: '@sergey-tihon/clippit-bin-linux-x64',    bin: 'clippit'     },
+  'win32-x64':     { pkg: '@sergey-tihon/clippit-bin-win32-x64',     bin: 'clippit.exe' },
+  'darwin-x64':    { pkg: '@sergey-tihon/clippit-bin-darwin-x64',    bin: 'clippit'     },
+  'darwin-arm64':  { pkg: '@sergey-tihon/clippit-bin-darwin-arm64',  bin: 'clippit'     },
+  'linux-x64':     { pkg: '@sergey-tihon/clippit-bin-linux-x64',     bin: 'clippit'     },
+  'linux-arm64':   { pkg: '@sergey-tihon/clippit-bin-linux-arm64',   bin: 'clippit'     },
 };
 
 /**

--- a/npm/clippit/package.json
+++ b/npm/clippit/package.json
@@ -24,7 +24,8 @@
     "@sergey-tihon/clippit-bin-win32-x64": "0.0.0",
     "@sergey-tihon/clippit-bin-darwin-x64": "0.0.0",
     "@sergey-tihon/clippit-bin-darwin-arm64": "0.0.0",
-    "@sergey-tihon/clippit-bin-linux-x64": "0.0.0"
+    "@sergey-tihon/clippit-bin-linux-x64": "0.0.0",
+    "@sergey-tihon/clippit-bin-linux-arm64": "0.0.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

Add Linux ARM64 () to the set of platforms supported by the Clippit CLI npm packages. Users on Linux ARM64 (e.g., Raspberry Pi 5, AWS Graviton, Ampere) can now install and run `clippit` via npm without emulation.

## Changes

| File | Change |
|---|---|
| `npm/clippit-linux-arm64/package.json` | **New** — platform package `@sergey-tihon/clippit-bin-linux-arm64` with `os: ["linux"], cpu: ["arm64"]` |
| `npm/clippit/index.js` | Added `linux-arm64` entry to `PLATFORM_PACKAGES` |
| `npm/clippit/package.json` | Added `@sergey-tihon/clippit-bin-linux-arm64` to `optionalDependencies` |
| `build.fsx` | Added `linux-arm64` to `cliRuntimes` list |
| `.github/workflows/publish-cli.yml` | Added `linux-arm64` matrix entry (`ubuntu-24.04-arm` runner), download step, and npm publish line. Changed NativeAOT toolchain condition to `startsWith(matrix.rid, 'linux-')` |
| `Clippit.Cli/CHANGELOG.md` | Added `v0.5.0` release notes |

Closes #360