### PR TITLE
feat(npm): add Windows ARM64 native binary support

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -37,6 +37,9 @@ jobs:
           - rid: win-x64
             os: windows-latest
             binary: clippit.exe
+          - rid: win-arm64
+            os: windows-11-arm
+            binary: clippit.exe
           - rid: osx-x64
             os: macos-15-intel
             binary: clippit
@@ -108,6 +111,12 @@ jobs:
           name: clippit-win-x64
           path: bin/cli/win-x64
 
+      - name: Download win-arm64 binary
+        uses: actions/download-artifact@v8
+        with:
+          name: clippit-win-arm64
+          path: bin/cli/win-arm64
+
       - name: Download osx-x64 binary
         uses: actions/download-artifact@v8
         with:
@@ -123,7 +132,7 @@ jobs:
       - name: Pack npm packages
         run: dotnet fsi build.fsx -- -p pack-npm
         env:
-          CLIPPIT_PUBLISH_RIDS: win-x64,osx-x64,osx-arm64,linux-x64,linux-arm64
+          CLIPPIT_PUBLISH_RIDS: win-x64,win-arm64,osx-x64,osx-arm64,linux-x64,linux-arm64
 
       - name: Upload npm tarballs
         uses: actions/upload-artifact@v7
@@ -140,6 +149,7 @@ jobs:
           npm publish bin/npm/sergey-tihon-clippit-bin-darwin-arm64-*.tgz --provenance --access public
           npm publish bin/npm/sergey-tihon-clippit-bin-linux-x64-*.tgz --provenance --access public
           npm publish bin/npm/sergey-tihon-clippit-bin-linux-arm64-*.tgz --provenance --access public
+          npm publish bin/npm/sergey-tihon-clippit-bin-win32-arm64-*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0] - 2026-06-29
+
+- feat(npm): add Windows ARM64 native binary support — new npm platform package
+  `@sergey-tihon/clippit-bin-win32-arm64` built on GitHub Actions
+  `windows-11-arm` runners (#363)
+
 ## [0.5.0] - 2026-06-29
 
 - feat(npm): add Linux ARM64 native binary support — new npm platform package

--- a/build.fsx
+++ b/build.fsx
@@ -25,7 +25,10 @@ let cliRuntimes =
         BinaryName = "clippit" }
       { Rid = "linux-arm64"
         NpmDirectory = "clippit-linux-arm64"
-        BinaryName = "clippit" } ]
+        BinaryName = "clippit" }
+      { Rid = "win-arm64"
+        NpmDirectory = "clippit-win32-arm64"
+        BinaryName = "clippit.exe" } ]
 
 let requestedRids =
     let value = System.Environment.GetEnvironmentVariable("CLIPPIT_PUBLISH_RIDS")
@@ -172,7 +175,7 @@ let publishCliBinaries () =
 let packNpmPackages () =
     if not allCliRuntimesRequested then
         failwith
-            "NPM wrapper package requires all CLI runtimes. Set CLIPPIT_PUBLISH_RIDS=win-x64,osx-x64,osx-arm64,linux-x64,linux-arm64."
+            "NPM wrapper package requires all CLI runtimes. Set CLIPPIT_PUBLISH_RIDS=win-x64,win-arm64,osx-x64,osx-arm64,linux-x64,linux-arm64."
 
     let npmDir = System.IO.Path.Combine(__SOURCE_DIRECTORY__, "npm")
 

--- a/npm/clippit-win32-arm64/package.json
+++ b/npm/clippit-win32-arm64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@sergey-tihon/clippit-bin-win32-arm64",
+  "version": "0.0.0",
+  "description": "Windows ARM64 binary for the Clippit CLI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sergey-tihon/Clippit.git",
+    "directory": "npm/clippit-win32-arm64"
+  },
+  "license": "MIT",
+  "os": ["win32"],
+  "cpu": ["arm64"],
+  "files": [
+    "clippit.exe"
+  ]
+}

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -68,6 +68,7 @@ Published JSON schemas for manifests and result payloads are available at
 | Platform      | Package                                   |
 | ------------- | ----------------------------------------- |
 | Windows x64   | `@sergey-tihon/clippit-bin-win32-x64`     |
+| Windows arm64 | `@sergey-tihon/clippit-bin-win32-arm64`   |
 | macOS x64     | `@sergey-tihon/clippit-bin-darwin-x64`    |
 | macOS arm64   | `@sergey-tihon/clippit-bin-darwin-arm64`  |
 | Linux x64     | `@sergey-tihon/clippit-bin-linux-x64`     |

--- a/npm/clippit/index.js
+++ b/npm/clippit/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const PLATFORM_PACKAGES = {
   'win32-x64':     { pkg: '@sergey-tihon/clippit-bin-win32-x64',     bin: 'clippit.exe' },
+  'win32-arm64':   { pkg: '@sergey-tihon/clippit-bin-win32-arm64',   bin: 'clippit.exe' },
   'darwin-x64':    { pkg: '@sergey-tihon/clippit-bin-darwin-x64',    bin: 'clippit'     },
   'darwin-arm64':  { pkg: '@sergey-tihon/clippit-bin-darwin-arm64',  bin: 'clippit'     },
   'linux-x64':     { pkg: '@sergey-tihon/clippit-bin-linux-x64',     bin: 'clippit'     },

--- a/npm/clippit/package.json
+++ b/npm/clippit/package.json
@@ -22,6 +22,7 @@
   ],
   "optionalDependencies": {
     "@sergey-tihon/clippit-bin-win32-x64": "0.0.0",
+    "@sergey-tihon/clippit-bin-win32-arm64": "0.0.0",
     "@sergey-tihon/clippit-bin-darwin-x64": "0.0.0",
     "@sergey-tihon/clippit-bin-darwin-arm64": "0.0.0",
     "@sergey-tihon/clippit-bin-linux-x64": "0.0.0",


### PR DESCRIPTION
## Summary

Add Windows ARM64 (`win-arm64`) to the set of platforms supported by the Clippit CLI npm packages. Users on Windows ARM64 (e.g., Surface Pro 11, Snapdragon X laptops) can now install and run `clippit` via npm natively without x64 emulation.

## Changes

| File | Change |
|---|---|
| `npm/clippit-win32-arm64/package.json` | **New** — platform package `@sergey-tihon/clippit-bin-win32-arm64` with `os: ["win32"], cpu: ["arm64"]` |
| `npm/clippit/index.js` | Added `win32-arm64` entry to `PLATFORM_PACKAGES` |
| `npm/clippit/package.json` | Added `@sergey-tihon/clippit-bin-win32-arm64` to `optionalDependencies` |
| `npm/clippit/README.md` | Added `Windows arm64` row to supported platforms table |
| `build.fsx` | Added `win-arm64` to `cliRuntimes` list and updated guidance text |
| `.github/workflows/publish-cli.yml` | Added `win-arm64` matrix entry (`windows-11-arm` runner), download step, and npm publish line |
| `Clippit.Cli/CHANGELOG.md` | Added `v0.6.0` release notes |

Closes #363