### PR TITLE
fix(Excel): keep tableColumns count in sync when data rows are wider than headings

### DIFF
--- a/Clippit.Tests/Excel/SpreadsheetWriterTests.cs
+++ b/Clippit.Tests/Excel/SpreadsheetWriterTests.cs
@@ -360,6 +360,69 @@ namespace Clippit.Tests.Excel
             await Validate(sDoc, s_spreadsheetExpectedErrors).ConfigureAwait(false);
         }
 
+        // Reproduces the malformed-table scenario: a sheet has fewer ColumnHeadings than
+        // data cells in the widest row, which previously caused tableColumns/@count to
+        // disagree with the actual number of tableColumn elements and Excel to remove the
+        // table on repair.
+        [Test]
+        public async Task SaveWorksheet_WithDataRowsWiderThanHeadings_ProducesValidTable()
+        {
+            var wb = new WorkbookDfn
+            {
+                Worksheets =
+                [
+                    new WorksheetDfn
+                    {
+                        Name = "WiderRows",
+                        TableName = "WiderTable",
+                        ColumnHeadings =
+                        [
+                            new CellDfn { Value = "A", Bold = true },
+                            new CellDfn { Value = "B", Bold = true },
+                            new CellDfn { Value = "C", Bold = true },
+                        ],
+                        Rows =
+                        [
+                            new RowDfn
+                            {
+                                Cells =
+                                [
+                                    new CellDfn { CellDataType = CellDataType.String, Value = "a" },
+                                    new CellDfn { CellDataType = CellDataType.String, Value = "b" },
+                                    new CellDfn { CellDataType = CellDataType.String, Value = "c" },
+                                    new CellDfn { CellDataType = CellDataType.String, Value = "d" },
+                                    new CellDfn { CellDataType = CellDataType.String, Value = "e" },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            var fileName = Path.Combine(TempDir, "SW006-WiderRows.xlsx");
+            await using (var stream = File.Open(fileName, FileMode.OpenOrCreate))
+                wb.WriteTo(stream);
+
+            using var sDoc = SpreadsheetDocument.Open(fileName, false);
+            var tablePart = sDoc.WorkbookPart.WorksheetParts.First().TableDefinitionParts.First();
+            var tableDoc = tablePart.GetXDocument();
+            var tableColumns = tableDoc.Root.Element(S.tableColumns);
+
+            var declaredCount = (int)tableColumns.Attribute("count");
+            var actualColumns = tableColumns.Elements(S.tableColumn).Count();
+            await Assert.That(declaredCount).IsEqualTo(5);
+            await Assert.That(actualColumns).IsEqualTo(5);
+
+            var names = tableColumns.Elements(S.tableColumn).Select(c => (string)c.Attribute("name")).ToList();
+            await Assert.That(names[0]).IsEqualTo("A");
+            await Assert.That(names[1]).IsEqualTo("B");
+            await Assert.That(names[2]).IsEqualTo("C");
+            await Assert.That(names[3]).IsEqualTo("Column4");
+            await Assert.That(names[4]).IsEqualTo("Column5");
+
+            await Validate(sDoc, s_spreadsheetExpectedErrors).ConfigureAwait(false);
+        }
+
         [Test]
         public async Task AddWorksheetToWorkbook()
         {

--- a/Clippit/Excel/SpreadsheetWriter.cs
+++ b/Clippit/Excel/SpreadsheetWriter.cs
@@ -376,34 +376,52 @@ namespace Clippit.Excel
 
                         var tableCount = sDoc.WorkbookPart!.WorksheetParts.Sum(wp => wp.TableDefinitionParts.Count());
 
+                        // Materialize the headings so we can handle data rows that are wider
+                        // (or narrower) than the supplied header row without producing a
+                        // malformed table definition.
+                        var columnHeadings = worksheetData.ColumnHeadings!.ToList();
+                        var tableRef = "A1:" + SpreadsheetMLUtil.IntToColumnId(totalColumns - 1) + totalRows;
+
+                        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        var fallbackSuffix = 1;
+                        var tableColumns = new List<XElement>(totalColumns);
+                        for (var i = 0; i < totalColumns; i++)
+                        {
+                            var heading = i < columnHeadings.Count ? columnHeadings[i] : null;
+                            var name = heading?.Value?.ToString().Trim() ?? string.Empty;
+
+                            if (string.IsNullOrWhiteSpace(name) || !usedNames.Add(name))
+                            {
+                                var fallbackBase = $"Column{i + 1}";
+                                var fallback = fallbackBase;
+                                while (!usedNames.Add(fallback))
+                                {
+                                    fallback = $"{fallbackBase}_{fallbackSuffix++}";
+                                }
+                                name = fallback;
+                            }
+
+                            tableColumns.Add(
+                                new XElement(
+                                    S.tableColumn,
+                                    new XAttribute(SSNoNamespace.id, i + 1),
+                                    new XAttribute(SSNoNamespace.name, name)
+                                )
+                            );
+                        }
+
                         var table = new XElement(
                             S.table,
                             new XAttribute(SSNoNamespace.id, tableCount + 1),
                             new XAttribute(SSNoNamespace.name, worksheetData.TableName),
                             new XAttribute(SSNoNamespace.displayName, worksheetData.TableName),
-                            new XAttribute(
-                                SSNoNamespace._ref,
-                                "A1:" + SpreadsheetMLUtil.IntToColumnId(totalColumns - 1) + totalRows
-                            ),
+                            new XAttribute(SSNoNamespace._ref, tableRef),
                             new XAttribute(SSNoNamespace.totalsRowShown, 0),
-                            new XElement(
-                                S.autoFilter,
-                                new XAttribute(
-                                    SSNoNamespace._ref,
-                                    "A1:" + SpreadsheetMLUtil.IntToColumnId(totalColumns - 1) + totalRows
-                                )
-                            ),
+                            new XElement(S.autoFilter, new XAttribute(SSNoNamespace._ref, tableRef)),
                             new XElement(
                                 S.tableColumns,
                                 new XAttribute(SSNoNamespace.count, totalColumns),
-                                worksheetData.ColumnHeadings.Select(
-                                    (ch, i) =>
-                                        new XElement(
-                                            S.tableColumn,
-                                            new XAttribute(SSNoNamespace.id, i + 1),
-                                            new XAttribute(SSNoNamespace.name, ch.Value)
-                                        )
-                                )
+                                tableColumns
                             ),
                             new XElement(
                                 S.tableStyleInfo,


### PR DESCRIPTION
When a worksheet's data rows have more cells than `ColumnHeadings` entries, the generated table definition now emits a placeholder `<tableColumn>` for each extra column instead of producing a mismatched `tableColumns/@count`.

Fixes the Excel repair error:
```
Removed Feature: AutoFilter from /xl/tables/table12.xml part (Table)
Removed Feature: Table from /xl/tables/table12.xml part (Table)
```

Changes:
- Pad missing table column names with Excel-style `ColumnN` placeholders (and de-duplicate names).
- Keep `tableColumns/@count` equal to the actual number of `<tableColumn>` elements.
- Added regression test `SaveWorksheet_WithDataRowsWiderThanHeadings_ProducesValidTable`.

Validation:
- `dotnet csharpier check .` passed
- `dotnet build Clippit.slnx -c Release` passed
- `dotnet test --project Clippit.Tests/ --treenode-filter "/*/*Excel*/**"` passed (326 tests)