### PR TITLE
[Clippy] feat(cli): add `clippit word assemble` command

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [0.7.0] - 2026-07-05
 
+- Added `word assemble` command to generate a `.docx` from a template and XML data.
+  Wraps `DocumentAssembler.AssembleDocument`. Supports `--output`/`-o` (defaults to
+  `<template>-assembled.docx`, `-` for stdout), `--force`, `--format json`, and
+  `--quiet`. The JSON result reports `template`, `data`, `output`, `outputSize`,
+  and `templateError`. Supports stdin (`-`) for one input. Published schema:
+  `assemble-result.v1.json` (#375).
 - Added `word accept-revisions` command to accept all tracked revisions in a `.docx` file.
   Wraps `RevisionAccepter.AcceptRevisions`. Supports `--output`/`-o` (defaults to
   `<input>-accepted.docx`, `-` for stdout), `--force`, `--format json`, and `--quiet`.

--- a/Clippit.Cli/CliJsonContext.cs
+++ b/Clippit.Cli/CliJsonContext.cs
@@ -4,6 +4,7 @@ using Clippit.Cli.Commands.Pptx.Build;
 using Clippit.Cli.Commands.Pptx.Split;
 using Clippit.Cli.Commands.Pptx.Verify;
 using Clippit.Cli.Commands.Version;
+using Clippit.Cli.Commands.Word.Assemble;
 using Clippit.Cli.Commands.Word.Compare;
 using Clippit.Cli.Infrastructure;
 
@@ -29,6 +30,7 @@ namespace Clippit.Cli;
 [JsonSerializable(typeof(VersionResult))]
 [JsonSerializable(typeof(ConvertResult))]
 [JsonSerializable(typeof(CompareResult))]
+[JsonSerializable(typeof(AssembleResult))]
 [JsonSerializable(typeof(ErrorResult))]
 [JsonSourceGenerationOptions(
     WriteIndented = false,

--- a/Clippit.Cli/Commands/Word/Assemble/AssembleResult.cs
+++ b/Clippit.Cli/Commands/Word/Assemble/AssembleResult.cs
@@ -1,0 +1,18 @@
+namespace Clippit.Cli.Commands.Word.Assemble;
+
+internal sealed record AssembleResult
+{
+    public required string Template { get; init; }
+    public required string Data { get; init; }
+    public required string Output { get; init; }
+    public required long OutputSize { get; init; }
+    public required bool TemplateError { get; init; }
+
+    public static void WriteText(AssembleResult result, TextWriter writer)
+    {
+        writer.WriteLine($"Created: {result.Output}");
+        writer.WriteLine($"Output size: {result.OutputSize} bytes");
+        if (result.TemplateError)
+            writer.WriteLine("Warning: template contained markup errors (see templateError in JSON mode)");
+    }
+}

--- a/Clippit.Cli/Commands/Word/Assemble/WordAssembleCommand.cs
+++ b/Clippit.Cli/Commands/Word/Assemble/WordAssembleCommand.cs
@@ -1,0 +1,87 @@
+using System.CommandLine;
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Word.Assemble;
+
+internal static class WordAssembleCommand
+{
+    public static Command Build()
+    {
+        var templateArg = InputSource.BuildArgument(
+            "template",
+            "Path to the template .docx file. Use '-' to read from stdin."
+        );
+        var dataArg = InputSource.BuildArgument(
+            "data",
+            "Path to the XML data file. Use '-' to read from stdin.",
+            "XML data file"
+        );
+
+        var outputOption = new Option<string>("--output", "-o")
+        {
+            Description =
+                "Output path for the assembled .docx file. "
+                + "Defaults to <template>-assembled.docx. Use '-' to write binary content to stdout.",
+        };
+
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Overwrite the output file if it already exists.",
+        };
+
+        var cmd = new Command(
+            "assemble",
+            "Assemble a .docx document from a template and XML data."
+                + "\n\nExamples:"
+                + "\n  clippit word assemble template.docx data.xml"
+                + "\n  clippit word assemble template.docx data.xml --output generated.docx --format json"
+                + "\n  clippit word assemble template.docx - --output generated.docx"
+                + "\n  clippit word assemble template.docx data.xml --output - > generated.docx"
+        );
+        cmd.Arguments.Add(templateArg);
+        cmd.Arguments.Add(dataArg);
+        cmd.Options.Add(outputOption);
+        cmd.Options.Add(forceOption);
+        var (formatOption, quietOption) = cmd.AddOutputOptions();
+
+        cmd.SetAction(parseResult =>
+            CommandRunner.Execute(() =>
+                Run(
+                    parseResult.GetValue(templateArg)!,
+                    parseResult.GetValue(dataArg)!,
+                    parseResult.GetValue(outputOption),
+                    parseResult.GetValue(forceOption),
+                    parseResult.GetValue(formatOption),
+                    parseResult.GetValue(quietOption)
+                )
+            )
+        );
+
+        return cmd;
+    }
+
+    private static int Run(
+        string templatePath,
+        string dataPath,
+        string? outputPath,
+        bool force,
+        OutputFormat format,
+        bool quiet
+    )
+    {
+        var template = InputSource.From(templatePath, "stdin-template.docx");
+        var data = InputSource.From(dataPath, "stdin-data.xml");
+        var defaultOutput = template.IsStdin
+            ? "assembled.docx"
+            : Path.Combine(
+                Path.GetDirectoryName(template.DisplayName)!,
+                $"{Path.GetFileNameWithoutExtension(template.DisplayName)}-assembled.docx"
+            );
+        var output = OutputTarget.FromOption(outputPath, () => defaultOutput);
+        var writer = new OutputWriter(format, quiet || output.IsStdout);
+
+        var result = WordAssembleService.Execute(template, data, output, force);
+        writer.WriteResult(result, CliJsonContext.Default.AssembleResult, AssembleResult.WriteText);
+        return ExitCodes.Success;
+    }
+}

--- a/Clippit.Cli/Commands/Word/Assemble/WordAssembleCommand.cs
+++ b/Clippit.Cli/Commands/Word/Assemble/WordAssembleCommand.cs
@@ -21,7 +21,8 @@ internal static class WordAssembleCommand
         {
             Description =
                 "Output path for the assembled .docx file. "
-                + "Defaults to <template>-assembled.docx. Use '-' to write binary content to stdout.",
+                + "Defaults to the template file name with '-assembled.docx' appended. "
+                + "Use '-' to write binary content to stdout.",
         };
 
         var forceOption = new Option<bool>("--force", "-f")

--- a/Clippit.Cli/Commands/Word/Assemble/WordAssembleService.cs
+++ b/Clippit.Cli/Commands/Word/Assemble/WordAssembleService.cs
@@ -1,0 +1,105 @@
+using System.Xml;
+using Clippit.Cli.Infrastructure;
+using Clippit.Word;
+
+namespace Clippit.Cli.Commands.Word.Assemble;
+
+internal static class WordAssembleService
+{
+    public static AssembleResult Execute(InputSource template, InputSource data, OutputTarget output, bool force)
+    {
+        ValidateInputs(template, data);
+
+        byte[] templateBytes;
+        using (var stream = template.OpenSeekable())
+        using (var memory = new MemoryStream())
+        {
+            stream.CopyTo(memory);
+            templateBytes = memory.ToArray();
+        }
+
+        string xmlContent;
+        using (var stream = data.OpenSeekable())
+        using (var reader = new StreamReader(stream))
+        {
+            xmlContent = reader.ReadToEnd();
+        }
+
+        var xmlDoc = new XmlDocument();
+        try
+        {
+            xmlDoc.LoadXml(xmlContent);
+        }
+        catch (XmlException ex)
+        {
+            throw CliException.InvalidFormat($"Data file is not valid XML: {ex.Message}");
+        }
+
+        var templateDoc = new WmlDocument(template.LogicalName, templateBytes);
+        WmlDocument assembled;
+        bool templateError;
+        try
+        {
+            assembled = DocumentAssembler.AssembleDocument(templateDoc, xmlDoc, out templateError);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.InvalidFormat($"Failed to assemble document: {ex.Message}");
+        }
+
+        string? tempPath = null;
+        Stream outputStream;
+        try
+        {
+            output.EnsureCanWrite(force, "output");
+            output.EnsureDirectoryExists();
+            outputStream = output.OpenWrite(out tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not open output for writing: {ex.Message}");
+        }
+
+        try
+        {
+            try
+            {
+                outputStream.Write(assembled.DocumentByteArray, 0, assembled.DocumentByteArray.Length);
+                outputStream.Flush();
+
+                if (output.IsStdout)
+                    output.Flush(outputStream);
+            }
+            finally
+            {
+                outputStream.Dispose();
+            }
+
+            if (!output.IsStdout)
+                output.Commit(tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not write output: {ex.Message}");
+        }
+        finally
+        {
+            OutputTarget.DeleteTemp(tempPath);
+        }
+
+        return new AssembleResult
+        {
+            Template = template.DisplayName,
+            Data = data.DisplayName,
+            Output = output.DisplayPath,
+            OutputSize = assembled.DocumentByteArray.Length,
+            TemplateError = templateError,
+        };
+    }
+
+    private static void ValidateInputs(InputSource template, InputSource data)
+    {
+        if (template.IsStdin && data.IsStdin)
+            throw CliException.InvalidArguments("Only one input can be read from stdin.");
+    }
+}

--- a/Clippit.Cli/Commands/Word/Assemble/WordAssembleService.cs
+++ b/Clippit.Cli/Commands/Word/Assemble/WordAssembleService.cs
@@ -8,7 +8,7 @@ internal static class WordAssembleService
 {
     public static AssembleResult Execute(InputSource template, InputSource data, OutputTarget output, bool force)
     {
-        ValidateInputs(template, data);
+        ValidateInputs(template, data, output);
 
         byte[] templateBytes;
         using (var stream = template.OpenSeekable())
@@ -18,17 +18,13 @@ internal static class WordAssembleService
             templateBytes = memory.ToArray();
         }
 
-        string xmlContent;
-        using (var stream = data.OpenSeekable())
-        using (var reader = new StreamReader(stream))
-        {
-            xmlContent = reader.ReadToEnd();
-        }
-
-        var xmlDoc = new XmlDocument();
+        var xmlDoc = new XmlDocument { XmlResolver = null };
         try
         {
-            xmlDoc.LoadXml(xmlContent);
+            using var stream = data.OpenSeekable();
+            var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null };
+            using var reader = XmlReader.Create(stream, settings);
+            xmlDoc.Load(reader);
         }
         catch (XmlException ex)
         {
@@ -36,16 +32,7 @@ internal static class WordAssembleService
         }
 
         var templateDoc = new WmlDocument(template.LogicalName, templateBytes);
-        WmlDocument assembled;
-        bool templateError;
-        try
-        {
-            assembled = DocumentAssembler.AssembleDocument(templateDoc, xmlDoc, out templateError);
-        }
-        catch (Exception ex) when (ex is not CliException)
-        {
-            throw CliException.InvalidFormat($"Failed to assemble document: {ex.Message}");
-        }
+        var assembled = DocumentAssembler.AssembleDocument(templateDoc, xmlDoc, out var templateError);
 
         string? tempPath = null;
         Stream outputStream;
@@ -97,9 +84,26 @@ internal static class WordAssembleService
         };
     }
 
-    private static void ValidateInputs(InputSource template, InputSource data)
+    private static void ValidateInputs(InputSource template, InputSource data, OutputTarget output)
     {
         if (template.IsStdin && data.IsStdin)
             throw CliException.InvalidArguments("Only one input can be read from stdin.");
+
+        if (output.IsStdout)
+            return;
+
+        if (!template.IsStdin && PathsEqual(output.DisplayPath, template.DisplayName))
+            throw CliException.OutputError("Output path must not overwrite the template document.");
+
+        if (!data.IsStdin && PathsEqual(output.DisplayPath, data.DisplayName))
+            throw CliException.OutputError("Output path must not overwrite the XML data file.");
     }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), PathComparison);
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
 }

--- a/Clippit.Cli/Commands/Word/WordCommand.cs
+++ b/Clippit.Cli/Commands/Word/WordCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using Clippit.Cli.Commands.Word.Assemble;
 using Clippit.Cli.Commands.Word.Compare;
 using Clippit.Cli.Commands.Word.FromHtml;
 using Clippit.Cli.Commands.Word.ToHtml;
@@ -14,6 +15,7 @@ internal static class WordCommand
     public static Command Build()
     {
         var cmd = new Command("word", "Work with Word (.docx) files");
+        cmd.Subcommands.Add(WordAssembleCommand.Build());
         cmd.Subcommands.Add(WordCompareCommand.Build());
         cmd.Subcommands.Add(WordVerifyCommand.Build());
         cmd.Subcommands.Add(WordToHtmlCommand.Build());

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -1,6 +1,6 @@
 # Clippit CLI — `dotnet tool`
 
-**Clippit CLI** is a command-line tool for working with OpenXml files (PowerPoint, Word, Excel), built on [Clippit](https://github.com/sergey-tihon/Clippit) — the .NET OpenXml PowerTools library. It supports PPTX split/build/verify workflows and DOCX↔HTML conversion.
+**Clippit CLI** is a command-line tool for working with OpenXml files (PowerPoint, Word, Excel), built on [Clippit](https://github.com/sergey-tihon/Clippit) — the .NET OpenXml PowerTools library. It supports PPTX split/build/verify workflows, DOCX template assembly, and DOCX↔HTML conversion.
 
 ## Installation
 
@@ -26,6 +26,9 @@ clippit word verify document.docx
 # Compare two DOCX files with tracked revisions
 clippit word compare before.docx after.docx --output compared.docx
 
+# Assemble a DOCX template with XML data
+clippit word assemble template.docx data.xml --output assembled.docx
+
 # Accept all tracked revisions in a DOCX file
 clippit word accept-revisions draft.docx
 
@@ -50,6 +53,7 @@ clippit pptx split presentation.pptx --format json
 | `pptx build init` | Scaffold a deck manifest (JSON). |
 | `pptx build run` | Assemble a `.pptx` from a deck manifest. |
 | `pptx verify` | Validate a PPTX — schema, relationships, markup compatibility, and sections. |
+| `word assemble` | Assemble a DOCX template with XML data. |
 | `word compare` | Compare two DOCX files and produce a tracked-revision DOCX. |
 | `word accept-revisions` | Accept all tracked revisions in a DOCX file. |
 | `word verify` | Validate a DOCX — schema and relationships. |

--- a/Clippit.Tests/Cli/Integration/Word/WordAssembleTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordAssembleTests.cs
@@ -35,12 +35,11 @@ internal sealed class WordAssembleTests : CliIntegrationTestBase
         await Assert.That(json.RootElement.GetProperty("data").GetString()).IsEqualTo(Data.FullName);
         await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(output.FullName);
         await Assert.That(json.RootElement.GetProperty("outputSize").GetInt64()).IsGreaterThan(0);
-        await Assert.That(json.RootElement.GetProperty("templateError").GetBoolean()).IsEqualTo(false);
+        await Assert.That(json.RootElement.GetProperty("templateError").GetBoolean()).IsFalse();
         await Assert.That(output.Exists).IsTrue();
 
-        // Document-level validation is covered by DocumentAssemblerTests; here we just check the file is valid docx.
         using var doc = WordprocessingDocument.Open(output.FullName, false);
-        await Assert.That(doc.MainDocumentPart).IsNotNull();
+        await Validate(doc, s_expectedErrors);
     }
 
     [Test]
@@ -148,7 +147,7 @@ internal sealed class WordAssembleTests : CliIntegrationTestBase
         await Assert.That(output.Exists).IsTrue();
 
         using var json = result.ReadStdoutJson();
-        await Assert.That(json.RootElement.GetProperty("templateError").GetBoolean()).IsEqualTo(true);
+        await Assert.That(json.RootElement.GetProperty("templateError").GetBoolean()).IsTrue();
     }
 
     [Test]
@@ -194,4 +193,90 @@ internal sealed class WordAssembleTests : CliIntegrationTestBase
         await Assert.That(result.StandardOutput[0]).IsEqualTo((byte)0x50);
         await Assert.That(result.StandardOutput[1]).IsEqualTo((byte)0x4B);
     }
+
+    [Test]
+    [Arguments("template")]
+    [Arguments("data")]
+    public async Task CLI118_WordAssemble_OutputPathMatchesInput_ReturnsOutputError(string conflictingInput)
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("da001-overwrite-guard");
+        var templateCopy = new FileInfo(Path.Combine(tempDir.FullName, "template.docx"));
+        var dataCopy = new FileInfo(Path.Combine(tempDir.FullName, "data.xml"));
+        File.Copy(Template.FullName, templateCopy.FullName, overwrite: true);
+        File.Copy(Data.FullName, dataCopy.FullName, overwrite: true);
+        var outputPath = conflictingInput == "template" ? templateCopy.FullName : dataCopy.FullName;
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "assemble",
+                templateCopy.FullName,
+                dataCopy.FullName,
+                "--output",
+                outputPath,
+                "--force",
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(5);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("must not overwrite");
+    }
+
+    [Test]
+    public async Task CLI119_WordAssemble_DtdInXmlData_ReturnsInvalidFormat()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "da001-dtd.docx"));
+        var dtdXmlBytes = System.Text.Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <!DOCTYPE Customer [<!ENTITY injected "blocked">]>
+            <Customer>
+                <Name>&injected;</Name>
+            </Customer>
+            """
+        );
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(
+                dtdXmlBytes,
+                "word",
+                "assemble",
+                Template.FullName,
+                "-",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("DTD");
+    }
+
+    private static readonly List<string> s_expectedErrors =
+    [
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenHBand' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenVBand' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstColumn' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstRow' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstRowFirstColumn' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstRowLastColumn' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastColumn' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastRow' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastRowFirstColumn' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastRowLastColumn' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:noHBand' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:noVBand' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:oddHBand' attribute is not declared.",
+        "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:oddVBand' attribute is not declared.",
+        "The 'http://schemas.microsoft.com/office/word/2012/wordml:restartNumberingAfterBreak' attribute is not declared.",
+        "The 'http://schemas.microsoft.com/office/word/2016/wordml/cid:durableId' attribute is not declared.",
+        "Attribute 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:val' should have unique value. Its current value",
+        "The element has unexpected child element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:bCs'.",
+        "The element has unexpected child element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:kern'.",
+        "The element has unexpected child element 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:rFonts'.",
+    ];
 }

--- a/Clippit.Tests/Cli/Integration/Word/WordAssembleTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordAssembleTests.cs
@@ -1,0 +1,197 @@
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Tests.Cli.Integration.Word;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class WordAssembleTests : CliIntegrationTestBase
+{
+    private static FileInfo Template => CliTestRunner.TestFile("DA/DA001-TemplateDocument.docx");
+    private static FileInfo Data => CliTestRunner.TestFile("DA/DA-Data.xml");
+    private static FileInfo TemplateWithErrors => CliTestRunner.TestFile("DA/DA003-Select-XPathFindsNoData.docx");
+
+    [Test]
+    public async Task CLI110_WordAssemble_ValidTemplateAndData_ReturnsResultAndWritesOutput()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "da001-assembled.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "assemble",
+                Template.FullName,
+                Data.FullName,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("template").GetString()).IsEqualTo(Template.FullName);
+        await Assert.That(json.RootElement.GetProperty("data").GetString()).IsEqualTo(Data.FullName);
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(output.FullName);
+        await Assert.That(json.RootElement.GetProperty("outputSize").GetInt64()).IsGreaterThan(0);
+        await Assert.That(json.RootElement.GetProperty("templateError").GetBoolean()).IsEqualTo(false);
+        await Assert.That(output.Exists).IsTrue();
+
+        // Document-level validation is covered by DocumentAssemblerTests; here we just check the file is valid docx.
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Assert.That(doc.MainDocumentPart).IsNotNull();
+    }
+
+    [Test]
+    public async Task CLI111_WordAssemble_DefaultOutputPath_WritesAdjacentFile()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("da001-default-output");
+        var templateCopy = new FileInfo(Path.Combine(tempDir.FullName, "DA001-TemplateDocument.docx"));
+        File.Copy(Template.FullName, templateCopy.FullName, overwrite: true);
+        var expectedOutput = new FileInfo(Path.Combine(tempDir.FullName, "DA001-TemplateDocument-assembled.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "assemble", templateCopy.FullName, Data.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(expectedOutput.Exists).IsTrue();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(expectedOutput.FullName);
+    }
+
+    [Test]
+    public async Task CLI112_WordAssemble_ReadsDataFromStdin()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "da001-stdin-data.docx"));
+        var dataBytes = await File.ReadAllBytesAsync(Data.FullName).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(
+                dataBytes,
+                "word",
+                "assemble",
+                Template.FullName,
+                "-",
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var stdout = System.Text.Encoding.UTF8.GetString(result.StandardOutput);
+        using var json = System.Text.Json.JsonDocument.Parse(stdout);
+        await Assert.That(json.RootElement.GetProperty("data").GetString()).IsEqualTo("<stdin>");
+        await Assert.That(output.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI113_WordAssemble_BothInputsFromStdin_ReturnsError()
+    {
+        var templateBytes = await File.ReadAllBytesAsync(Template.FullName).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(templateBytes, "word", "assemble", "-", "-", "--output", "out.docx")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+        await Assert.That(result.StandardError).Contains("stdin");
+    }
+
+    [Test]
+    public async Task CLI114_WordAssemble_MalformedXmlData_ReturnsInvalidFormat()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "da001-bad-xml.docx"));
+        var badXmlBytes = System.Text.Encoding.UTF8.GetBytes("<NotXml>missing close");
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(
+                badXmlBytes,
+                "word",
+                "assemble",
+                Template.FullName,
+                "-",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4); // INVALID_FORMAT
+        await Assert.That(result.StandardError).Contains("XML");
+    }
+
+    [Test]
+    public async Task CLI115_WordAssemble_TemplateError_ReportsInResult()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "da003-assembled.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "assemble",
+                TemplateWithErrors.FullName,
+                Data.FullName,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(output.Exists).IsTrue();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("templateError").GetBoolean()).IsEqualTo(true);
+    }
+
+    [Test]
+    public async Task CLI116_WordAssemble_QuietMode_SuppressesOutput()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "da001-quiet.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "assemble",
+                Template.FullName,
+                Data.FullName,
+                "--output",
+                output.FullName,
+                "--quiet"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI117_WordAssemble_OutputToStdout_WritesDocxBytes()
+    {
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(
+                Array.Empty<byte>(),
+                "word",
+                "assemble",
+                Template.FullName,
+                Data.FullName,
+                "--output",
+                "-"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput.Length).IsGreaterThan(0);
+        // ZIP magic bytes: PK (0x50 0x4B)
+        await Assert.That(result.StandardOutput[0]).IsEqualTo((byte)0x50);
+        await Assert.That(result.StandardOutput[1]).IsEqualTo((byte)0x4B);
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,7 @@ clippit version
 clippit pptx split deck.pptx --output slides --manifest
 clippit pptx build run slides/deck.manifest.json --output final.pptx
 clippit pptx verify final.pptx
+clippit word assemble template.docx data.xml --output assembled.docx
 clippit word compare before.docx after.docx --output compared.docx
 clippit word accept-revisions draft.docx
 clippit word verify document.docx
@@ -64,12 +65,14 @@ Agents and scripts should use `--format json` when they need machine-readable co
 | stdout | Successful JSON command | Command-specific result JSON. |
 | stdout | `pptx verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
 | stdout | `word verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
+| stdout | `word assemble` | Result JSON (e.g. `{"template":...,"data":...,"output":...,"outputSize":...,"templateError":...}`); assembled DOCX written to `--output` path. |
 | stdout | `word compare` | Result JSON (e.g. `{"source":...,"revised":...,"output":...,"revisions":...}`); compared DOCX written to `--output` path. |
 | stdout | `excel verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
 | stdout | `word to-html` / `word from-html` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); converted content written to `--output` path. |
 | stdout | `word accept-revisions` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); cleaned DOCX written to `--output` path. |
 | stdout | `excel to-html` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); converted HTML written to `--output` path. |
 | stdout | `pptx build run --output -` | Binary `.pptx`; no success summary is written. |
+| stdout | `word assemble --output -` | Binary `.docx` streamed to stdout; no success summary is written. |
 | stdout | `word to-html --output -` / `word from-html --output -` | Binary/HTML content streamed to stdout; no success summary is written. |
 | stdout | `word accept-revisions --output -` | Binary `.docx` streamed to stdout; no success summary is written. |
 | stdout | `excel to-html --output -` | HTML content streamed to stdout; no success summary is written. |
@@ -97,6 +100,7 @@ Commands that accept files use `-` for stdin where binary or JSON streaming is s
 cat deck.pptx | clippit pptx split - --output slides --format json
 cat deck.json | clippit pptx build run - --output - > final.pptx
 cat deck.pptx | clippit pptx verify - --format json
+cat data.xml | clippit word assemble template.docx - --output assembled.docx --format json
 cat before.docx | clippit word compare - after.docx --output compared.docx --format json
 cat document.docx | clippit word verify - --format json
 cat document.docx | clippit word accept-revisions - --output clean.docx --format json
@@ -106,6 +110,8 @@ cat spreadsheet.xlsx | clippit excel verify - --format json
 ```
 
 When `pptx build run --output -` writes a `.pptx` to stdout, the success summary is suppressed automatically so the binary stream is not corrupted.
+
+When `word assemble --output -` writes a `.docx` to stdout, the success summary is also suppressed so the binary stream is not corrupted.
 
 When `word to-html --output -` or `word from-html --output -` writes content to stdout, the success summary is also suppressed so the output stream is not corrupted.
 
@@ -363,6 +369,39 @@ JSON example (for `--author "Jane Doe" --date-time 2026-01-01T00:00:00Z --output
 {"source":"/work/before.docx","revised":"/work/after.docx","output":"/work/compared.docx","outputSize":59321,"revisions":8,"authorForRevisions":"Jane Doe","dateTimeForRevisions":"2026-01-01T00:00:00Z","caseInsensitive":false}
 ```
 
+## `word assemble`
+
+Assembles a `.docx` document from a template and XML data.
+The command wraps `DocumentAssembler.AssembleDocument`.
+
+Synopsis:
+
+```text
+clippit word assemble <template.docx|-> <data.xml|-> [--output <file.docx|->] [--force] [--format json|text] [--quiet]
+```
+
+```bash
+clippit word assemble template.docx data.xml
+clippit word assemble template.docx data.xml --output assembled.docx --format json
+clippit word assemble template.docx - --output assembled.docx
+cat data.xml | clippit word assemble template.docx - --output assembled.docx --format json
+```
+
+Options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--output`, `-o` | Output path for the assembled `.docx` file. Defaults to `<template>-assembled.docx`. Use `-` to write binary content to stdout. |
+| `--force` | Overwrite the output file if it already exists. |
+
+Only one input can be read from stdin at a time. The output path must not overwrite the template or XML data input file, even when `--force` is used.
+
+JSON example:
+
+```json
+{"template":"/work/template.docx","data":"/work/data.xml","output":"/work/template-assembled.docx","outputSize":42130,"templateError":false}
+```
+
 ## `word accept-revisions`
 
 Accepts all tracked revisions in a `.docx` file and writes the cleaned document.
@@ -512,5 +551,6 @@ Canonical schema URLs:
 | `pptx split` result | `https://sergey-tihon.github.io/Clippit/schemas/split-result.v1.json` |
 | `pptx build run` result | `https://sergey-tihon.github.io/Clippit/schemas/build-result.v1.json` |
 | `pptx verify`, `word verify`, `excel verify` result | `https://sergey-tihon.github.io/Clippit/schemas/verify-result.v1.json` |
+| `word assemble` result | `https://sergey-tihon.github.io/Clippit/schemas/assemble-result.v1.json` |
 | `word compare` result | `https://sergey-tihon.github.io/Clippit/schemas/compare-result.v1.json` |
 | `word to-html`, `word from-html`, `word accept-revisions` result | `https://sergey-tihon.github.io/Clippit/schemas/convert-result.v1.json` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -270,7 +270,7 @@
 
 # Clippit — Fresh PowerTools for OpenXml
 
-Clippit is a .NET library for programmatically creating, modifying, and converting Word (DOCX), Excel (XLSX), and PowerPoint (PPTX) documents. Built on top of the [Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK), it provides high-level APIs that handle the complexity of the Open XML format so you can focus on your content. It also includes a [scriptable CLI](cli.md) for PowerPoint split, build, and validation workflows.
+Clippit is a .NET library for programmatically creating, modifying, and converting Word (DOCX), Excel (XLSX), and PowerPoint (PPTX) documents. Built on top of the [Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK), it provides high-level APIs that handle the complexity of the Open XML format so you can focus on your content. It also includes a [scriptable CLI](cli.md) for PowerPoint split/build workflows, Word template assembly, and document validation/conversion tasks.
 
 ## Getting Started
 

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -15,6 +15,7 @@ published for documentation, integration validation, and contract tests.
 | [`build-result.v1.json`](./build-result.v1.json)       | Stdout payload of `clippit pptx build run` (JSON mode)       |
 | [`verify-result.v1.json`](./verify-result.v1.json)     | Stdout payload of `clippit pptx verify`, `clippit word verify`, `clippit excel verify` (JSON mode) |
 | [`compare-result.v1.json`](./compare-result.v1.json)   | Stdout payload of `clippit word compare` (JSON mode)          |
+| [`assemble-result.v1.json`](./assemble-result.v1.json) | Stdout payload of `clippit word assemble` (JSON mode)         |
 | [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, or `clippit excel to-html` (JSON mode) |
 
 ## Output discipline

--- a/docs/schemas/assemble-result.v1.json
+++ b/docs/schemas/assemble-result.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sergey-tihon.github.io/Clippit/schemas/assemble-result.v1.json",
+  "title": "Clippit word assemble result",
+  "description": "Result payload of `clippit word assemble` written to stdout in JSON mode.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "template",
+    "data",
+    "output",
+    "outputSize",
+    "templateError"
+  ],
+  "properties": {
+    "template": {
+      "type": "string",
+      "description": "Absolute path of the template .docx file, or '<stdin>' when read from stdin."
+    },
+    "data": {
+      "type": "string",
+      "description": "Absolute path of the XML data file, or '<stdin>' when read from stdin."
+    },
+    "output": {
+      "type": "string",
+      "description": "Absolute path of the assembled output file, or '<stdout>' when written to stdout."
+    },
+    "outputSize": {
+      "type": "integer",
+      "description": "Size of the assembled output .docx file in bytes."
+    },
+    "templateError": {
+      "type": "boolean",
+      "description": "true when the assembler detected template markup errors but still emitted a document."
+    }
+  }
+}

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -24,6 +24,9 @@ clippit pptx verify presentation.pptx
 # Validate a DOCX file
 clippit word verify document.docx
 
+# Assemble a DOCX template with XML data
+clippit word assemble template.docx data.xml --output assembled.docx
+
 # Validate an XLSX file
 clippit excel verify spreadsheet.xlsx
 
@@ -39,6 +42,7 @@ clippit pptx split presentation.pptx --format json
 | `pptx build init` | Scaffold a deck manifest (JSON).                                                                                                        |
 | `pptx build run`  | Assemble a `.pptx` from a deck manifest.                                                                                                |
 | `pptx verify`           | Validate a PPTX — schema, relationships, markup compatibility, and sections.                                                            |
+| `word assemble`         | Assemble a DOCX template with XML data.                                                                                                  |
 | `word compare`          | Compare two DOCX files and produce a tracked-revision DOCX.                                                                             |
 | `word accept-revisions` | Accept all tracked revisions in a DOCX file.                                                                                            |
 | `word verify`           | Validate a DOCX — schema and relationships.                                                                                             |


### PR DESCRIPTION
Implements the DocumentAssembler as a CLI command (closes #375).

- New command: clippit word assemble <template> <data> [options]
  - template: path or stdin (-) for the .docx template
  - data: path or stdin (-) for the XML data document
  - --output: destination path or - for stdout (default: <name>-assembled.docx)
  - --force: overwrite existing output files
  - --format: text (default) or json
  - --quiet: suppress stdout
- JSON output schema: docs/schemas/assemble-result.v1.json
  - Fields: template, data, output, outputSize, templateError
- AOT-safe: AssembleResult registered in CliJsonContext
- 8 integration tests (CLI110–CLI117) covering success paths,
  template errors, stdin input, stdout output, and error conditions

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
