### PR TITLE
[Clippy] feat(cli): add `clippit word accept-revisions` command

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.7.0] - 2026-07-05
+
+- Added `word accept-revisions` command to accept all tracked revisions in a `.docx` file.
+  Wraps `RevisionAccepter.AcceptRevisions`. Supports `--output`/`-o` (defaults to
+  `<input>-accepted.docx`, `-` for stdout), `--force`, `--format json`, and `--quiet`.
+  The JSON result reports `input`, `output`, and `outputSize` (same shape as
+  `convert-result.v1.json`). Supports stdin (`-`) for input (#376).
+
 ## [0.6.0] - 2026-06-29
 
 - Added `word compare` command to compare two `.docx` files with `WmlComparer` and

--- a/Clippit.Cli/Commands/Word/AcceptRevisions/WordAcceptRevisionsCommand.cs
+++ b/Clippit.Cli/Commands/Word/AcceptRevisions/WordAcceptRevisionsCommand.cs
@@ -1,0 +1,69 @@
+using System.CommandLine;
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Word.AcceptRevisions;
+
+internal static class WordAcceptRevisionsCommand
+{
+    public static Command Build()
+    {
+        var inputArg = InputSource.BuildArgument("input", "Path to the .docx file. Use '-' to read from stdin.");
+
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description =
+                "Output path for the cleaned .docx. "
+                + "Defaults to <input>-accepted.docx. Use '-' to write binary content to stdout.",
+        };
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Overwrite the output file if it already exists.",
+        };
+
+        var cmd = new Command(
+            "accept-revisions",
+            "Accept all tracked revisions in a .docx file."
+                + "\n\nExamples:"
+                + "\n  clippit word accept-revisions draft.docx"
+                + "\n  clippit word accept-revisions draft.docx --output clean.docx --format json"
+                + "\n  cat draft.docx | clippit word accept-revisions - --output clean.docx"
+                + "\n  clippit word accept-revisions draft.docx --output - > clean.docx"
+        );
+        cmd.Arguments.Add(inputArg);
+        cmd.Options.Add(outputOption);
+        cmd.Options.Add(forceOption);
+        var (formatOption, quietOption) = cmd.AddOutputOptions();
+
+        cmd.SetAction(parseResult =>
+            CommandRunner.Execute(() =>
+                Run(
+                    parseResult.GetValue(inputArg)!,
+                    parseResult.GetValue(outputOption),
+                    parseResult.GetValue(forceOption),
+                    parseResult.GetValue(formatOption),
+                    parseResult.GetValue(quietOption)
+                )
+            )
+        );
+
+        return cmd;
+    }
+
+    private static int Run(string inputPath, string? outputPath, bool force, OutputFormat format, bool quiet)
+    {
+        var input = InputSource.From(inputPath, "stdin.docx");
+        var defaultOutput = input.IsStdin
+            ? "accepted.docx"
+            : Path.Combine(
+                Path.GetDirectoryName(input.DisplayName)!,
+                $"{Path.GetFileNameWithoutExtension(input.DisplayName)}-accepted.docx"
+            );
+        var output = OutputTarget.FromOption(outputPath, () => defaultOutput);
+        var writer = new OutputWriter(format, quiet || output.IsStdout);
+
+        var result = WordAcceptRevisionsService.Execute(input, output, force);
+        writer.WriteResult(result, CliJsonContext.Default.ConvertResult, ConvertResult.WriteText);
+        return ExitCodes.Success;
+    }
+}

--- a/Clippit.Cli/Commands/Word/AcceptRevisions/WordAcceptRevisionsService.cs
+++ b/Clippit.Cli/Commands/Word/AcceptRevisions/WordAcceptRevisionsService.cs
@@ -1,0 +1,90 @@
+using Clippit.Cli.Infrastructure;
+using Clippit.Word;
+
+namespace Clippit.Cli.Commands.Word.AcceptRevisions;
+
+internal static class WordAcceptRevisionsService
+{
+    public static ConvertResult Execute(InputSource input, OutputTarget output, bool force)
+    {
+        if (!output.IsStdout)
+        {
+            if (!input.IsStdin && PathsEqual(output.DisplayPath, input.DisplayName))
+                throw CliException.OutputError("Output path must not overwrite the input document.");
+        }
+
+        byte[] inputBytes;
+        using (var stream = input.OpenSeekable())
+        using (var memory = new MemoryStream())
+        {
+            stream.CopyTo(memory);
+            inputBytes = memory.ToArray();
+        }
+
+        WmlDocument accepted;
+        try
+        {
+            var wml = new WmlDocument(input.LogicalName, inputBytes);
+            accepted = RevisionAccepter.AcceptRevisions(wml);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.InvalidFormat($"Could not process document: {ex.Message}");
+        }
+
+        string? tempPath = null;
+        Stream outputStream;
+        try
+        {
+            output.EnsureCanWrite(force, "output");
+            output.EnsureDirectoryExists();
+            outputStream = output.OpenWrite(out tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not open output for writing: {ex.Message}");
+        }
+
+        try
+        {
+            try
+            {
+                outputStream.Write(accepted.DocumentByteArray, 0, accepted.DocumentByteArray.Length);
+                outputStream.Flush();
+
+                if (output.IsStdout)
+                    output.Flush(outputStream);
+            }
+            finally
+            {
+                outputStream.Dispose();
+            }
+
+            if (!output.IsStdout)
+                output.Commit(tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not write output: {ex.Message}");
+        }
+        finally
+        {
+            OutputTarget.DeleteTemp(tempPath);
+        }
+
+        return new ConvertResult
+        {
+            Input = input.DisplayName,
+            Output = output.DisplayPath,
+            OutputSize = accepted.DocumentByteArray.Length,
+        };
+    }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), PathComparison);
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+}

--- a/Clippit.Cli/Commands/Word/WordCommand.cs
+++ b/Clippit.Cli/Commands/Word/WordCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using Clippit.Cli.Commands.Word.AcceptRevisions;
 using Clippit.Cli.Commands.Word.Compare;
 using Clippit.Cli.Commands.Word.FromHtml;
 using Clippit.Cli.Commands.Word.ToHtml;
@@ -14,6 +15,7 @@ internal static class WordCommand
     public static Command Build()
     {
         var cmd = new Command("word", "Work with Word (.docx) files");
+        cmd.Subcommands.Add(WordAcceptRevisionsCommand.Build());
         cmd.Subcommands.Add(WordCompareCommand.Build());
         cmd.Subcommands.Add(WordVerifyCommand.Build());
         cmd.Subcommands.Add(WordToHtmlCommand.Build());

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -26,6 +26,9 @@ clippit word verify document.docx
 # Compare two DOCX files with tracked revisions
 clippit word compare before.docx after.docx --output compared.docx
 
+# Accept all tracked revisions in a DOCX file
+clippit word accept-revisions draft.docx
+
 # Convert DOCX to HTML
 clippit word to-html document.docx
 
@@ -48,6 +51,7 @@ clippit pptx split presentation.pptx --format json
 | `pptx build run` | Assemble a `.pptx` from a deck manifest. |
 | `pptx verify` | Validate a PPTX — schema, relationships, markup compatibility, and sections. |
 | `word compare` | Compare two DOCX files and produce a tracked-revision DOCX. |
+| `word accept-revisions` | Accept all tracked revisions in a DOCX file. |
 | `word verify` | Validate a DOCX — schema and relationships. |
 | `word to-html` | Convert a DOCX to HTML/CSS. |
 | `word from-html` | Convert HTML/CSS to a DOCX. |

--- a/Clippit.Tests/Cli/Integration/Word/WordAcceptRevisionsTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordAcceptRevisionsTests.cs
@@ -1,0 +1,166 @@
+using System.Text;
+using Clippit.Word;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Tests.Cli.Integration.Word;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class WordAcceptRevisionsTests : CliIntegrationTestBase
+{
+    [Test]
+    public async Task CLI097_WordAcceptRevisions_DocumentWithRevisions_AcceptsAndWritesOutput()
+    {
+        var input = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("accept-revisions-basic");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "clean.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "accept-revisions",
+                input.FullName,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo(input.FullName);
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(output.FullName);
+        await Assert.That(json.RootElement.GetProperty("outputSize").GetInt64()).IsGreaterThan(0);
+        await Assert.That(output.Exists).IsTrue();
+
+        // Verify all tracked revisions are gone
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Assert.That(RevisionAccepter.HasTrackedRevisions(doc)).IsFalse();
+    }
+
+    [Test]
+    public async Task CLI098_WordAcceptRevisions_DefaultOutputPathDerivedFromInput()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("accept-revisions-default-output");
+        var source = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
+        var localInput = new FileInfo(Path.Combine(tempDir.FullName, "RA001-Tracked-Revisions-01.docx"));
+        File.Copy(source.FullName, localInput.FullName);
+
+        var expectedOutput = new FileInfo(Path.Combine(tempDir.FullName, "RA001-Tracked-Revisions-01-accepted.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "accept-revisions", localInput.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(expectedOutput.FullName);
+        await Assert.That(expectedOutput.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI099_WordAcceptRevisions_DocumentAlreadyClean_CopiesUnchanged()
+    {
+        // Use a document that has no tracked revisions — the output should still be a valid docx.
+        var input = CliTestRunner.TestFile("Blank-wml.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("accept-revisions-clean");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "clean.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "accept-revisions",
+                input.FullName,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Assert.That(RevisionAccepter.HasTrackedRevisions(doc)).IsFalse();
+        await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI100_WordAcceptRevisions_ReadsFromStdin_ProducesOutput()
+    {
+        var input = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("accept-revisions-stdin");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "clean.docx"));
+        var inputBytes = await File.ReadAllBytesAsync(input.FullName).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(
+                inputBytes,
+                "word",
+                "accept-revisions",
+                "-",
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        var stdout = Encoding.UTF8.GetString(result.StandardOutput);
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = System.Text.Json.JsonDocument.Parse(stdout);
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo("<stdin>");
+        await Assert.That(output.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI101_WordAcceptRevisions_QuietSuppressesStdout()
+    {
+        var input = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("accept-revisions-quiet");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "clean.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "accept-revisions", input.FullName, "--output", output.FullName, "--quiet")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI102_WordAcceptRevisions_ExistingOutputWithoutForce_ReturnsOutputError()
+    {
+        var input = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("accept-revisions-no-force");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "clean.docx"));
+        await File.WriteAllTextAsync(output.FullName, "placeholder").ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "accept-revisions",
+                input.FullName,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(5);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("OUTPUT_ERROR");
+    }
+}
+#pragma warning restore CA1707

--- a/Clippit.Tests/Cli/Integration/Word/WordAcceptRevisionsTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordAcceptRevisionsTests.cs
@@ -35,9 +35,10 @@ internal sealed class WordAcceptRevisionsTests : CliIntegrationTestBase
         await Assert.That(json.RootElement.GetProperty("outputSize").GetInt64()).IsGreaterThan(0);
         await Assert.That(output.Exists).IsTrue();
 
-        // Verify all tracked revisions are gone
+        // Verify all tracked revisions are gone and no relationships are broken
         using var doc = WordprocessingDocument.Open(output.FullName, false);
         await Assert.That(RevisionAccepter.HasTrackedRevisions(doc)).IsFalse();
+        await ValidateRelationships(doc);
     }
 
     [Test]
@@ -161,6 +162,51 @@ internal sealed class WordAcceptRevisionsTests : CliIntegrationTestBase
         await Assert.That(result.ExitCode).IsEqualTo(5);
         await Assert.That(result.StandardOutput).IsEmpty();
         await Assert.That(result.StandardError).Contains("OUTPUT_ERROR");
+    }
+
+    [Test]
+    public async Task CLI103_WordAcceptRevisions_OutputToStdout_StreamsBinaryDocx()
+    {
+        var input = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
+        var inputBytes = await File.ReadAllBytesAsync(input.FullName).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(inputBytes, "word", "accept-revisions", "-", "--output", "-")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        // When --output -, stdout is the binary DOCX content, not a success payload
+        await Assert.That(result.StandardOutput.Length).IsGreaterThan(0);
+        // Verify it looks like a ZIP/DOCX (PK header)
+        await Assert.That(result.StandardOutput[0]).IsEqualTo((byte)'P');
+        await Assert.That(result.StandardOutput[1]).IsEqualTo((byte)'K');
+    }
+
+    [Test]
+    public async Task CLI104_WordAcceptRevisions_InvalidDocxInput_ReturnsInvalidFormat()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("accept-revisions-invalid");
+        var badInput = new FileInfo(Path.Combine(tempDir.FullName, "not-a-docx.docx"));
+        await File.WriteAllTextAsync(badInput.FullName, "This is not a valid DOCX file.").ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "output.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "accept-revisions",
+                badInput.FullName,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("INVALID_FORMAT");
     }
 }
 #pragma warning restore CA1707

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,7 @@ clippit pptx split deck.pptx --output slides --manifest
 clippit pptx build run slides/deck.manifest.json --output final.pptx
 clippit pptx verify final.pptx
 clippit word compare before.docx after.docx --output compared.docx
+clippit word accept-revisions draft.docx
 clippit word verify document.docx
 clippit word to-html document.docx
 clippit word from-html article.html --css styles.css
@@ -66,9 +67,11 @@ Agents and scripts should use `--format json` when they need machine-readable co
 | stdout | `word compare` | Result JSON (e.g. `{"source":...,"revised":...,"output":...,"revisions":...}`); compared DOCX written to `--output` path. |
 | stdout | `excel verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
 | stdout | `word to-html` / `word from-html` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); converted content written to `--output` path. |
+| stdout | `word accept-revisions` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); cleaned DOCX written to `--output` path. |
 | stdout | `excel to-html` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); converted HTML written to `--output` path. |
 | stdout | `pptx build run --output -` | Binary `.pptx`; no success summary is written. |
 | stdout | `word to-html --output -` / `word from-html --output -` | Binary/HTML content streamed to stdout; no success summary is written. |
+| stdout | `word accept-revisions --output -` | Binary `.docx` streamed to stdout; no success summary is written. |
 | stdout | `excel to-html --output -` | HTML content streamed to stdout; no success summary is written. |
 | stderr | Command execution error | Compact JSON error object: `{"error":"...","code":"..."}`. |
 | stderr/stdout | Parser, arity, and help output | System.CommandLine text output, not JSON. |
@@ -96,6 +99,7 @@ cat deck.json | clippit pptx build run - --output - > final.pptx
 cat deck.pptx | clippit pptx verify - --format json
 cat before.docx | clippit word compare - after.docx --output compared.docx --format json
 cat document.docx | clippit word verify - --format json
+cat document.docx | clippit word accept-revisions - --output clean.docx --format json
 cat document.docx | clippit word to-html - --inline-images --output -
 cat article.html | clippit word from-html - --minor-font "Georgia" --output -
 cat spreadsheet.xlsx | clippit excel verify - --format json
@@ -104,6 +108,8 @@ cat spreadsheet.xlsx | clippit excel verify - --format json
 When `pptx build run --output -` writes a `.pptx` to stdout, the success summary is suppressed automatically so the binary stream is not corrupted.
 
 When `word to-html --output -` or `word from-html --output -` writes content to stdout, the success summary is also suppressed so the output stream is not corrupted.
+
+When `word accept-revisions --output -` writes a `.docx` to stdout, the success summary is also suppressed so the binary stream is not corrupted.
 
 Binary stdout output is buffered in memory before it is written to stdout. Prefer file output for very large decks.
 
@@ -357,6 +363,37 @@ JSON example (for `--author "Jane Doe" --date-time 2026-01-01T00:00:00Z --output
 {"source":"/work/before.docx","revised":"/work/after.docx","output":"/work/compared.docx","outputSize":59321,"revisions":8,"authorForRevisions":"Jane Doe","dateTimeForRevisions":"2026-01-01T00:00:00Z","caseInsensitive":false}
 ```
 
+## `word accept-revisions`
+
+Accepts all tracked revisions in a `.docx` file and writes the cleaned document.
+The command wraps `RevisionAccepter.AcceptRevisions`.
+
+Synopsis:
+
+```text
+clippit word accept-revisions <input.docx|-> [--output <file.docx|->] [--force] [--format json|text] [--quiet]
+```
+
+```bash
+clippit word accept-revisions draft.docx
+clippit word accept-revisions draft.docx --output clean.docx --format json
+clippit word accept-revisions draft.docx --output - > clean.docx
+cat draft.docx | clippit word accept-revisions - --output clean.docx --format json
+```
+
+Options:
+
+| Option | Description |
+| ------ | ----------- |
+| `--output`, `-o` | Output path for the cleaned `.docx` file. Defaults to `<input>-accepted.docx`. Use `-` to write binary content to stdout. |
+| `--force` | Overwrite the output file if it already exists. |
+
+JSON example:
+
+```json
+{"input":"/work/draft.docx","output":"/work/draft-accepted.docx","outputSize":42130}
+```
+
 ## `excel verify`
 
 Validates that a `.xlsx` file is a readable and structurally correct Open XML spreadsheet. The command checks package readability, Open XML schema errors, dangling relationships, and markup compatibility issues.
@@ -476,4 +513,4 @@ Canonical schema URLs:
 | `pptx build run` result | `https://sergey-tihon.github.io/Clippit/schemas/build-result.v1.json` |
 | `pptx verify`, `word verify`, `excel verify` result | `https://sergey-tihon.github.io/Clippit/schemas/verify-result.v1.json` |
 | `word compare` result | `https://sergey-tihon.github.io/Clippit/schemas/compare-result.v1.json` |
-| `word to-html`, `word from-html` result | `https://sergey-tihon.github.io/Clippit/schemas/convert-result.v1.json` |
+| `word to-html`, `word from-html`, `word accept-revisions` result | `https://sergey-tihon.github.io/Clippit/schemas/convert-result.v1.json` |

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -15,7 +15,7 @@ published for documentation, integration validation, and contract tests.
 | [`build-result.v1.json`](./build-result.v1.json)       | Stdout payload of `clippit pptx build run` (JSON mode)       |
 | [`verify-result.v1.json`](./verify-result.v1.json)     | Stdout payload of `clippit pptx verify`, `clippit word verify`, `clippit excel verify` (JSON mode) |
 | [`compare-result.v1.json`](./compare-result.v1.json)   | Stdout payload of `clippit word compare` (JSON mode)          |
-| [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, or `clippit excel to-html` (JSON mode) |
+| [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, `clippit word accept-revisions`, or `clippit excel to-html` (JSON mode) |
 
 ## Output discipline
 

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -38,8 +38,10 @@ clippit pptx split presentation.pptx --format json
 | `pptx split`      | Split a `.pptx` into individual single-slide files. Supports slide range selection (`--slides`) and manifest generation (`--manifest`). |
 | `pptx build init` | Scaffold a deck manifest (JSON).                                                                                                        |
 | `pptx build run`  | Assemble a `.pptx` from a deck manifest.                                                                                                |
-| `pptx verify`     | Validate a PPTX — schema, relationships, markup compatibility, and sections.                                                            |
-| `word verify`     | Validate a DOCX — schema and relationships.                                                                                             |
+| `pptx verify`           | Validate a PPTX — schema, relationships, markup compatibility, and sections.                                                            |
+| `word compare`          | Compare two DOCX files and produce a tracked-revision DOCX.                                                                             |
+| `word accept-revisions` | Accept all tracked revisions in a DOCX file.                                                                                            |
+| `word verify`           | Validate a DOCX — schema and relationships.                                                                                             |
 | `word to-html`    | Convert a DOCX to HTML/CSS.                                                                                                             |
 | `word from-html`  | Convert HTML/CSS to a DOCX.                                                                                                             |
 | `excel to-html`   | Convert an XLSX sheet, range, or table to HTML/CSS.                                                                                     |


### PR DESCRIPTION
Implements `clippit word accept-revisions <input>` exposing
RevisionAccepter.AcceptRevisions via the CLI (closes #376).

## What's added

- `Commands/Word/AcceptRevisions/WordAcceptRevisionsCommand.cs` — thin
  command with --output, --force, --format, --quiet options
- `Commands/Word/AcceptRevisions/WordAcceptRevisionsService.cs` — calls
  RevisionAccepter.AcceptRevisions and writes the result
- Reuses existing `ConvertResult` DTO (no new JSON shape)
- Hooked into `WordCommand` alphabetically
- Updated `docs/schemas/README.md` to list this command as a consumer of
  `convert-result.v1.json`
- 6 integration tests (CLI097–CLI102) in WordAcceptRevisionsTests.cs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
