### PR TITLE
[Clippy] ci: migrate NuGet publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
             - name: NuGet login (OIDC → temp API key)
               uses: NuGet/login@v1
               id: login
-              with:
-                  user: ${{ secrets.NUGET_USER }}
             - name: Publish to NuGet
               run: |
                   dotnet nuget push bin/*.nupkg \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
+            id-token: write
 
         steps:
             - name: Checkout
@@ -20,10 +21,23 @@ jobs:
                   global-json-file: global.json
             - name: Build and Pack
               run: dotnet fsi build.fsx -- -p build
+            - name: Get NuGet API Key via OIDC
+              id: get-nuget-key
+              run: |
+                  OIDC_TOKEN=$(curl -sSf \
+                    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+                    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api.nuget.org" \
+                    | jq -r .value)
+                  NUGET_API_KEY=$(curl -sSf \
+                    -X POST "https://www.nuget.org/api/v1/authorize-exchange" \
+                    -H "Content-Type: application/json" \
+                    --data-raw "{\"oidcToken\":\"${OIDC_TOKEN}\"}" \
+                    | jq -r .apiKey)
+                  echo "apiKey=${NUGET_API_KEY}" >> "${GITHUB_OUTPUT}"
             - name: Publish to NuGet
               run: |
                   dotnet nuget push bin/*.nupkg \
-                    --api-key ${{ secrets.NUGET_API_KEY }} \
+                    --api-key ${{ steps.get-nuget-key.outputs.apiKey }} \
                     --source https://api.nuget.org/v3/index.json \
                     --skip-duplicate
             - name: Create GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,23 +21,15 @@ jobs:
                   global-json-file: global.json
             - name: Build and Pack
               run: dotnet fsi build.fsx -- -p build
-            - name: Get NuGet API Key via OIDC
-              id: get-nuget-key
-              run: |
-                  OIDC_TOKEN=$(curl -sSf \
-                    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-                    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api.nuget.org" \
-                    | jq -r .value)
-                  NUGET_API_KEY=$(curl -sSf \
-                    -X POST "https://www.nuget.org/api/v1/authorize-exchange" \
-                    -H "Content-Type: application/json" \
-                    --data-raw "{\"oidcToken\":\"${OIDC_TOKEN}\"}" \
-                    | jq -r .apiKey)
-                  echo "apiKey=${NUGET_API_KEY}" >> "${GITHUB_OUTPUT}"
+            - name: NuGet login (OIDC → temp API key)
+              uses: NuGet/login@v1
+              id: login
+              with:
+                  user: ${{ secrets.NUGET_USER }}
             - name: Publish to NuGet
               run: |
                   dotnet nuget push bin/*.nupkg \
-                    --api-key ${{ steps.get-nuget-key.outputs.apiKey }} \
+                    --api-key ${{ steps.login.outputs.NUGET_API_KEY }} \
                     --source https://api.nuget.org/v3/index.json \
                     --skip-duplicate
             - name: Create GitHub Release


### PR DESCRIPTION
Closes #401
Closes #403 

Replaces the long-lived NUGET_API_KEY secret with GitHub OIDC tokens
for NuGet Trusted Publishing, following the Microsoft documentation at
https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing

Changes:
- Add 'id-token: write' permission to the publish job
- Exchange GitHub OIDC token for a temporary NuGet API key via
  https://www.nuget.org/api/v1/authorize-exchange before pushing
- Remove dependency on the NUGET_API_KEY repository secret

Prerequisites (manual step required by maintainer):
- On NuGet.org, configure a Trusted Publisher for each package:
  Manage package → Trusted Publishers → Add GitHub Actions publisher
  Specify: repository = sergey-tihon/Clippit, workflow = publish.yml,
  tag/branch pattern matching v* tags

The NUGET_API_KEY secret can be removed from repository settings after
the trusted publisher is configured and this change is verified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
