### PR TITLE
Fix DocumentAssembler xml:space preservation for content text

### DIFF
--- a/Clippit.Tests/Word/DocumentAssemblerTests.cs
+++ b/Clippit.Tests/Word/DocumentAssemblerTests.cs
@@ -542,6 +542,37 @@ public class DocumentAssemblerTests : TestsBase
     }
 
     [Test]
+    public async Task DA_Content_LeadingAndTrailingWhitespace_Preserved()
+    {
+        var bodyXml = new XElement(
+            W.body,
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, @"<# <Content Select=""./Value"" /> #>"))),
+            new XElement(W.sectPr)
+        );
+
+        var wmlTemplate = BuildTemplate("content-whitespace-template.docx", bodyXml);
+        var xmlData = XElement.Parse("<Data><Value>  padded value  </Value></Data>");
+
+        var result = DocumentAssembler.AssembleDocument(wmlTemplate, xmlData, out var hasError);
+
+        await Assert.That(hasError).IsFalse();
+
+        using var resultStream = new MemoryStream(result.DocumentByteArray);
+        using var resultDoc = WordprocessingDocument.Open(resultStream, false);
+        await Validate(resultDoc, s_expectedErrors);
+
+        var textElement = resultDoc
+            .MainDocumentPart!.GetXDocument()
+            .Descendants(W.t)
+            .FirstOrDefault(t => (string)t == "  padded value  ");
+        await Assert.That(textElement).IsNotNull();
+
+        var xmlSpaceAttribute = textElement!.Attribute(XNamespace.Xml + "space");
+        await Assert.That(xmlSpaceAttribute).IsNotNull();
+        await Assert.That(xmlSpaceAttribute!.Value).IsEqualTo("preserve");
+    }
+
+    [Test]
     [Arguments("DA-Issue-95-Template.docx", "DA-Issue-95-Data.xml", false)]
     public async Task DA_Issue_95_Repro(string name, string data, bool err)
     {

--- a/Clippit.Tests/Word/DocumentAssemblerTests.cs
+++ b/Clippit.Tests/Word/DocumentAssemblerTests.cs
@@ -5,8 +5,10 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Clippit.Word;
+using Clippit.Word.Assembler;
 using DocumentFormat.OpenXml.Packaging;
 using SkiaSharp;
+using AssemblerHtmlConverter = Clippit.Word.Assembler.HtmlConverter;
 
 namespace Clippit.Tests.Word;
 
@@ -573,7 +575,7 @@ public class DocumentAssemblerTests : TestsBase
     }
 
     [Test]
-    public async Task DA_Content_HyperlinkText_LeadingAndTrailingWhitespace_Preserved()
+    public async Task DA290_Content_HyperlinkText_LeadingAndTrailingWhitespace_Preserved()
     {
         using var documentStream = new MemoryStream();
         using var wordDoc = WordprocessingDocument.Create(
@@ -583,8 +585,8 @@ public class DocumentAssemblerTests : TestsBase
         var mainPart = wordDoc.AddMainDocumentPart();
         mainPart.PutXDocument(new XDocument(new XElement(W.document, new XElement(W.body, new XElement(W.p)))));
 
-        var templateError = new Clippit.Word.Assembler.TemplateError();
-        var runs = Clippit.Word.Assembler.HtmlConverter.ConvertTextToRunsWithMarkupSupport(
+        var templateError = new TemplateError();
+        var runs = AssemblerHtmlConverter.ConvertTextToRunsWithMarkupSupport(
             ["<p><a href=\"https://example.com\">  padded link  </a></p>"],
             mainPart,
             templateError
@@ -593,10 +595,10 @@ public class DocumentAssemblerTests : TestsBase
         await Assert.That(templateError.HasError).IsFalse();
 
         var hyperlinkTextElement = runs.SelectMany(e => e.DescendantsAndSelf(W.t))
-            .FirstOrDefault(t => ((string)t)?.Trim() == "padded link");
+            .FirstOrDefault(t => t.Value.Trim() == "padded link");
         await Assert.That(hyperlinkTextElement).IsNotNull();
-        await Assert.That(((string)hyperlinkTextElement)!.StartsWith(" ", StringComparison.Ordinal)).IsTrue();
-        await Assert.That(((string)hyperlinkTextElement)!.EndsWith(" ", StringComparison.Ordinal)).IsTrue();
+        var hyperlinkText = (string)hyperlinkTextElement ?? string.Empty;
+        await Assert.That(hyperlinkText).IsEqualTo("  padded link  ");
 
         var hyperlinkXmlSpaceAttribute = hyperlinkTextElement!.Attribute(XNamespace.Xml + "space");
         await Assert.That(hyperlinkXmlSpaceAttribute).IsNotNull();

--- a/Clippit.Tests/Word/DocumentAssemblerTests.cs
+++ b/Clippit.Tests/Word/DocumentAssemblerTests.cs
@@ -573,6 +573,37 @@ public class DocumentAssemblerTests : TestsBase
     }
 
     [Test]
+    public async Task DA_Content_HyperlinkText_LeadingAndTrailingWhitespace_Preserved()
+    {
+        using var documentStream = new MemoryStream();
+        using var wordDoc = WordprocessingDocument.Create(
+            documentStream,
+            DocumentFormat.OpenXml.WordprocessingDocumentType.Document
+        );
+        var mainPart = wordDoc.AddMainDocumentPart();
+        mainPart.PutXDocument(new XDocument(new XElement(W.document, new XElement(W.body, new XElement(W.p)))));
+
+        var templateError = new Clippit.Word.Assembler.TemplateError();
+        var runs = Clippit.Word.Assembler.HtmlConverter.ConvertTextToRunsWithMarkupSupport(
+            ["<p><a href=\"https://example.com\">  padded link  </a></p>"],
+            mainPart,
+            templateError
+        );
+
+        await Assert.That(templateError.HasError).IsFalse();
+
+        var hyperlinkTextElement = runs.SelectMany(e => e.DescendantsAndSelf(W.t))
+            .FirstOrDefault(t => ((string)t)?.Trim() == "padded link");
+        await Assert.That(hyperlinkTextElement).IsNotNull();
+        await Assert.That(((string)hyperlinkTextElement)!.StartsWith(" ", StringComparison.Ordinal)).IsTrue();
+        await Assert.That(((string)hyperlinkTextElement)!.EndsWith(" ", StringComparison.Ordinal)).IsTrue();
+
+        var hyperlinkXmlSpaceAttribute = hyperlinkTextElement!.Attribute(XNamespace.Xml + "space");
+        await Assert.That(hyperlinkXmlSpaceAttribute).IsNotNull();
+        await Assert.That(hyperlinkXmlSpaceAttribute!.Value).IsEqualTo("preserve");
+    }
+
+    [Test]
     [Arguments("DA-Issue-95-Template.docx", "DA-Issue-95-Data.xml", false)]
     public async Task DA_Issue_95_Repro(string name, string data, bool err)
     {

--- a/Clippit/Word/Assembler/HtmlConverter.cs
+++ b/Clippit/Word/Assembler/HtmlConverter.cs
@@ -93,7 +93,7 @@ namespace Clippit.Word.Assembler
                                 if (splitRun == "\t")
                                     results.Add(SoftTab);
                                 else
-                                    results.Add(new XElement(W.r, new XElement(W.t, splitRun)));
+                                    results.Add(new XElement(W.r, CreateTextElement(splitRun)));
                             }
                         }
                     }
@@ -128,6 +128,11 @@ namespace Clippit.Word.Assembler
 
         private static bool IsSoftBreak(XElement element) =>
             element.Name == W.r && element.Elements().Count() == 1 && element.Element(W.br) is not null;
+
+        private static XElement CreateTextElement(string value)
+        {
+            return new XElement(W.t, XmlUtil.GetXmlSpaceAttribute(value), value);
+        }
 
         private static List<object> FlattenResults(object obj)
         {
@@ -203,7 +208,7 @@ namespace Clippit.Word.Assembler
                         catch (UriFormatException)
                         {
                             var rPr = HtmlToWmlConverterCore.GetRunProperties(element, settings);
-                            var run = new XElement(W.r, rPr, new XElement(W.t, element.Value));
+                            var run = new XElement(W.r, rPr, CreateTextElement(element.Value));
                             return new[] { run };
                         }
 
@@ -249,7 +254,7 @@ namespace Clippit.Word.Assembler
                             var hyperlink = new XElement(
                                 W.hyperlink,
                                 new XAttribute(R.id, newRel.Id),
-                                new XElement(W.r, rPr, new XElement(W.t, element.Value))
+                                new XElement(W.r, rPr, CreateTextElement(element.Value))
                             );
 
                             if (nextExpected == NextExpected.Paragraph)


### PR DESCRIPTION
Summary:
- Set xml:space preserve for plain-text w:t runs created by HtmlConverter when content has leading or trailing spaces.
- Apply the same behavior for hyperlink-related plain-text run creation paths.
- Add focused regression test DA_Content_LeadingAndTrailingWhitespace_Preserved.

Validation:
- dotnet test --project Clippit.Tests/ --treenode-filter /*/*/*/DA_Content_LeadingAndTrailingWhitespace_Preserved**
- dotnet csharpier format .
- ./build.sh

Part 1 of #386.