### PR TITLE
Fix OpenXmlRegex matching with lastRenderedPageBreak

### DIFF
--- a/Clippit.Tests/Common/OpenXmlRegexTests.cs
+++ b/Clippit.Tests/Common/OpenXmlRegexTests.cs
@@ -196,6 +196,17 @@ public class OpenXmlRegexTests : TestsBase
   </w:body>
 </w:document>";
 
+    private const string LastRenderedPageBreakDocumentXmlString =
+        @"<w:document xmlns:w=""http://schemas.openxmlformats.org/wordprocessingml/2006/main"">
+  <w:body>
+    <w:p>
+      <w:r><w:t>ABC</w:t></w:r>
+      <w:r><w:lastRenderedPageBreak/></w:r>
+      <w:r><w:t>DEF</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>";
+
     private static string InnerText(XContainer e)
     {
         return e.Descendants(W.r)
@@ -377,5 +388,34 @@ public class OpenXmlRegexTests : TestsBase
         await Assert
             .That(innerText)
             .IsEqualTo("As stated in Article {__1} and this Section {__1.1}, this is described in Exhibit 4.");
+    }
+
+    [Test]
+    public async Task CanMatchAndReplaceAcrossLastRenderedPageBreak()
+    {
+        var partDocument = XDocument.Parse(LastRenderedPageBreakDocumentXmlString);
+        var p = partDocument.Descendants(W.p).First();
+        var innerText = InnerText(p);
+
+        await Assert.That(innerText).IsEqualTo("ABCDEF");
+
+        using var stream = new MemoryStream();
+        using var wordDocument = WordprocessingDocument.Create(stream, DocumentType);
+        var part = wordDocument.AddMainDocumentPart();
+        part.PutXDocument(partDocument);
+
+        var content = partDocument.Descendants(W.p);
+        var regex = new Regex("CDE");
+
+        var matchCount = OpenXmlRegex.Match(content, regex);
+        await Assert.That(matchCount).IsEqualTo(1);
+
+        var replaceCount = OpenXmlRegex.Replace(content, regex, "X", null);
+        await Assert.That(replaceCount).IsEqualTo(1);
+
+        p = partDocument.Descendants(W.p).First();
+        innerText = InnerText(p);
+        await Assert.That(innerText).IsEqualTo("ABXF");
+        await Assert.That(p.Descendants(W.lastRenderedPageBreak)).IsNotEmpty();
     }
 }

--- a/Clippit/OpenXmlRegex.cs
+++ b/Clippit/OpenXmlRegex.cs
@@ -531,8 +531,8 @@ namespace Clippit
             if (run.Name != W.r)
                 return false;
 
-            var nonPropertyElements = run.Elements().Where(e => e.Name != W.rPr).ToList();
-            return nonPropertyElements.Count > 0 && nonPropertyElements.All(e => e.Name == W.lastRenderedPageBreak);
+            var nonPropertyElements = run.Elements().Where(e => e.Name != W.rPr);
+            return nonPropertyElements.Any() && nonPropertyElements.All(e => e.Name == W.lastRenderedPageBreak);
         }
 
         private static object PmlSearchAndReplaceTransform(

--- a/Clippit/OpenXmlRegex.cs
+++ b/Clippit/OpenXmlRegex.cs
@@ -267,7 +267,10 @@ namespace Clippit
                         .DescendantsTrimmed(W.txbxContent)
                         .Where(d => d.Name == W.r && (d.Parent is null || d.Parent.Name != W.del));
 
-                    var charsAndRuns = runsTrimmed.Select(r => new { Ch = UnicodeMapper.RunToString(r), r }).ToList();
+                    var charsAndRuns = runsTrimmed
+                        .Select(r => new { Ch = UnicodeMapper.RunToString(r), r })
+                        .Where(t => !(string.IsNullOrEmpty(t.Ch) && IsRunWithOnlyLastRenderedPageBreak(t.r)))
+                        .ToList();
 
                     var content = charsAndRuns
                         // each run should take some space in content to be able to be covered by regex and replaced/deleted
@@ -521,6 +524,15 @@ namespace Clippit
                 return new XElement(W.delText, XmlUtil.GetXmlSpaceAttribute(element.Value), element.Value);
 
             return new XElement(element.Name, element.Attributes(), element.Nodes().Select(TransformToDelText));
+        }
+
+        private static bool IsRunWithOnlyLastRenderedPageBreak(XElement run)
+        {
+            if (run.Name != W.r)
+                return false;
+
+            var nonPropertyElements = run.Elements().Where(e => e.Name != W.rPr).ToList();
+            return nonPropertyElements.Count > 0 && nonPropertyElements.All(e => e.Name == W.lastRenderedPageBreak);
         }
 
         private static object PmlSearchAndReplaceTransform(


### PR DESCRIPTION
Summary:
- Ignore runs that contain only w:lastRenderedPageBreak when building OpenXmlRegex run-to-character alignment.
- Prevent invisible page break markers from consuming regex character positions.
- Add regression test CanMatchAndReplaceAcrossLastRenderedPageBreak.

Validation:
- dotnet test --project Clippit.Tests/ --treenode-filter /*/*/OpenXmlRegexTests/**
- dotnet csharpier format .
- ./build.sh

Part 2 of #386.