### PR TITLE
[Clippy] feat(cli): add `clippit word simplify-markup` command

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [0.7.0] - 2026-07-05
 
+- Added `word simplify-markup` command to remove non-content markup from a `.docx` file.
+  Wraps `MarkupSimplifier.SimplifyMarkup`. Accepts one flag per `SimplifyMarkupSettings`
+  boolean field (`--accept-revisions`, `--remove-rsid-info`, `--remove-markup-for-document-comparison`,
+  `--remove-comments`, `--remove-bookmarks`, `--remove-content-controls`,
+  `--remove-end-and-footnotes`, `--remove-field-codes`, `--remove-go-back-bookmark`,
+  `--remove-hyperlinks`, `--remove-last-rendered-page-break`, `--remove-permissions`,
+  `--remove-proof`, `--remove-smart-tags`, `--remove-soft-hyphens`, `--remove-web-hidden`,
+  `--replace-tabs-with-spaces`, `--normalize-xml`) plus `--all` as a convenience preset
+  that enables every option. Supports `--output`/`-o` (defaults to
+  `<input>-simplified.docx`, `-` for stdout), `--force`, `--format json`, and `--quiet`.
+  At least one flag must be supplied or `INVALID_ARGUMENTS` (exit 2) is returned.
+  The JSON result reuses the `convert-result.v1.json` shape (`input`, `output`,
+  `outputSize`). Supports stdin (`-`) for input (#377).
 - Added `word assemble` command to generate a `.docx` from a template and XML data.
   Wraps `DocumentAssembler.AssembleDocument`. Supports `--output`/`-o` (defaults to
   `<template>-assembled.docx`, `-` for stdout), `--force`, `--format json`, and

--- a/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
+++ b/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
@@ -1,0 +1,227 @@
+using System.CommandLine;
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Word.SimplifyMarkup;
+
+internal static class WordSimplifyMarkupCommand
+{
+    public static Command Build()
+    {
+        var inputArg = InputSource.BuildArgument("input", "Path to the .docx file. Use '-' to read from stdin.");
+
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description =
+                "Output path for the simplified .docx. "
+                + "Defaults to <input>-simplified.docx. Use '-' to write binary content to stdout.",
+        };
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Overwrite the output file if it already exists.",
+        };
+
+        // Simplification flags
+        var allOption = new Option<bool>("--all") { Description = "Enable all cleanup flags (convenience preset)." };
+        var acceptRevisionsOption = new Option<bool>("--accept-revisions")
+        {
+            Description = "Accept all tracked revisions before simplification.",
+        };
+        var removeRsidInfoOption = new Option<bool>("--remove-rsid-info")
+        {
+            Description = "Remove RSID attributes from settings and content.",
+        };
+        var removeMarkupForDocCompOption = new Option<bool>("--remove-markup-for-document-comparison")
+        {
+            Description = "Remove document properties and markup used for comparison (implies --remove-rsid-info).",
+        };
+        var removeCommentsOption = new Option<bool>("--remove-comments")
+        {
+            Description = "Remove comments and comment-extended markup.",
+        };
+        var removeBookmarksOption = new Option<bool>("--remove-bookmarks")
+        {
+            Description = "Remove bookmarks (including _GoBack).",
+        };
+        var removeContentControlsOption = new Option<bool>("--remove-content-controls")
+        {
+            Description = "Remove structured document tags, keeping their content.",
+        };
+        var removeEndAndFootnotesOption = new Option<bool>("--remove-end-and-footnotes")
+        {
+            Description = "Remove endnotes and footnotes.",
+        };
+        var removeFieldCodesOption = new Option<bool>("--remove-field-codes")
+        {
+            Description = "Remove field codes, leaving the last cached result text.",
+        };
+        var removeGoBackBookmarkOption = new Option<bool>("--remove-go-back-bookmark")
+        {
+            Description = "Remove the _GoBack bookmark specifically.",
+        };
+        var removeHyperlinksOption = new Option<bool>("--remove-hyperlinks")
+        {
+            Description = "Remove hyperlink relationships and markup.",
+        };
+        var removeLastRenderedPageBreakOption = new Option<bool>("--remove-last-rendered-page-break")
+        {
+            Description = "Remove lastRenderedPageBreak elements.",
+        };
+        var removePermissionsOption = new Option<bool>("--remove-permissions")
+        {
+            Description = "Remove permission and editable-region markup.",
+        };
+        var removeProofOption = new Option<bool>("--remove-proof") { Description = "Remove proofing errors." };
+        var removeSmartTagsOption = new Option<bool>("--remove-smart-tags")
+        {
+            Description = "Remove smart-tag wrappers.",
+        };
+        var removeSoftHyphensOption = new Option<bool>("--remove-soft-hyphens")
+        {
+            Description = "Remove soft hyphen characters.",
+        };
+        var removeWebHiddenOption = new Option<bool>("--remove-web-hidden") { Description = "Remove web-hidden text." };
+        var replaceTabsWithSpacesOption = new Option<bool>("--replace-tabs-with-spaces")
+        {
+            Description = "Replace tab characters with spaces.",
+        };
+        var normalizeXmlOption = new Option<bool>("--normalize-xml")
+        {
+            Description = "Apply the library's XML normalization step.",
+        };
+
+        var cmd = new Command(
+            "simplify-markup",
+            "Simplify markup in a .docx file by removing non-content elements."
+                + "\n\nAt least one simplification flag must be provided, or use --all."
+                + "\n\nExamples:"
+                + "\n  clippit word simplify-markup noisy.docx --remove-rsid-info --remove-comments --output clean.docx"
+                + "\n  clippit word simplify-markup noisy.docx --all --output clean.docx"
+                + "\n  clippit word simplify-markup noisy.docx --all --format json"
+        );
+
+        cmd.Arguments.Add(inputArg);
+        cmd.Options.Add(outputOption);
+        cmd.Options.Add(forceOption);
+        cmd.Options.Add(allOption);
+        cmd.Options.Add(acceptRevisionsOption);
+        cmd.Options.Add(removeRsidInfoOption);
+        cmd.Options.Add(removeMarkupForDocCompOption);
+        cmd.Options.Add(removeCommentsOption);
+        cmd.Options.Add(removeBookmarksOption);
+        cmd.Options.Add(removeContentControlsOption);
+        cmd.Options.Add(removeEndAndFootnotesOption);
+        cmd.Options.Add(removeFieldCodesOption);
+        cmd.Options.Add(removeGoBackBookmarkOption);
+        cmd.Options.Add(removeHyperlinksOption);
+        cmd.Options.Add(removeLastRenderedPageBreakOption);
+        cmd.Options.Add(removePermissionsOption);
+        cmd.Options.Add(removeProofOption);
+        cmd.Options.Add(removeSmartTagsOption);
+        cmd.Options.Add(removeSoftHyphensOption);
+        cmd.Options.Add(removeWebHiddenOption);
+        cmd.Options.Add(replaceTabsWithSpacesOption);
+        cmd.Options.Add(normalizeXmlOption);
+
+        var (formatOption, quietOption) = cmd.AddOutputOptions();
+
+        cmd.SetAction(parseResult =>
+            CommandRunner.Execute(() =>
+                Run(
+                    parseResult.GetValue(inputArg)!,
+                    parseResult.GetValue(outputOption),
+                    parseResult.GetValue(forceOption),
+                    parseResult.GetValue(allOption),
+                    parseResult.GetValue(acceptRevisionsOption),
+                    parseResult.GetValue(removeRsidInfoOption),
+                    parseResult.GetValue(removeMarkupForDocCompOption),
+                    parseResult.GetValue(removeCommentsOption),
+                    parseResult.GetValue(removeBookmarksOption),
+                    parseResult.GetValue(removeContentControlsOption),
+                    parseResult.GetValue(removeEndAndFootnotesOption),
+                    parseResult.GetValue(removeFieldCodesOption),
+                    parseResult.GetValue(removeGoBackBookmarkOption),
+                    parseResult.GetValue(removeHyperlinksOption),
+                    parseResult.GetValue(removeLastRenderedPageBreakOption),
+                    parseResult.GetValue(removePermissionsOption),
+                    parseResult.GetValue(removeProofOption),
+                    parseResult.GetValue(removeSmartTagsOption),
+                    parseResult.GetValue(removeSoftHyphensOption),
+                    parseResult.GetValue(removeWebHiddenOption),
+                    parseResult.GetValue(replaceTabsWithSpacesOption),
+                    parseResult.GetValue(normalizeXmlOption),
+                    parseResult.GetValue(formatOption),
+                    parseResult.GetValue(quietOption)
+                )
+            )
+        );
+
+        return cmd;
+    }
+
+    private static int Run(
+        string inputPath,
+        string? outputPath,
+        bool force,
+        bool all,
+        bool acceptRevisions,
+        bool removeRsidInfo,
+        bool removeMarkupForDocComp,
+        bool removeComments,
+        bool removeBookmarks,
+        bool removeContentControls,
+        bool removeEndAndFootnotes,
+        bool removeFieldCodes,
+        bool removeGoBackBookmark,
+        bool removeHyperlinks,
+        bool removeLastRenderedPageBreak,
+        bool removePermissions,
+        bool removeProof,
+        bool removeSmartTags,
+        bool removeSoftHyphens,
+        bool removeWebHidden,
+        bool replaceTabsWithSpaces,
+        bool normalizeXml,
+        OutputFormat format,
+        bool quiet
+    )
+    {
+        var input = InputSource.From(inputPath, "stdin.docx");
+        var defaultOutput = input.IsStdin
+            ? "simplified.docx"
+            : Path.Combine(
+                Path.GetDirectoryName(input.DisplayName)!,
+                $"{Path.GetFileNameWithoutExtension(input.DisplayName)}-simplified.docx"
+            );
+        var output = OutputTarget.FromOption(outputPath, () => defaultOutput);
+        var writer = new OutputWriter(format, quiet || output.IsStdout);
+
+        var result = WordSimplifyMarkupService.Execute(
+            input,
+            output,
+            force,
+            all,
+            acceptRevisions,
+            removeRsidInfo,
+            removeMarkupForDocComp,
+            removeComments,
+            removeBookmarks,
+            removeContentControls,
+            removeEndAndFootnotes,
+            removeFieldCodes,
+            removeGoBackBookmark,
+            removeHyperlinks,
+            removeLastRenderedPageBreak,
+            removePermissions,
+            removeProof,
+            removeSmartTags,
+            removeSoftHyphens,
+            removeWebHidden,
+            replaceTabsWithSpaces,
+            normalizeXml
+        );
+
+        writer.WriteResult(result, CliJsonContext.Default.ConvertResult, ConvertResult.WriteText);
+        return ExitCodes.Success;
+    }
+}

--- a/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
+++ b/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
@@ -13,8 +13,7 @@ internal static class WordSimplifyMarkupCommand
         {
             Description =
                 "Output path for the simplified .docx. "
-                + "Defaults to <input>-simplified.docx. Use '-' to write binary content to stdout.",
-        };
+                + "Defaults to <input>-simplified.docx (or simplified.docx when reading from stdin). Use '-' to write binary content to stdout.",
 
         var forceOption = new Option<bool>("--force")
         {

--- a/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
+++ b/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
@@ -128,30 +128,32 @@ internal static class WordSimplifyMarkupCommand
         cmd.SetAction(parseResult =>
             CommandRunner.Execute(() =>
                 Run(
-                    parseResult.GetValue(inputArg)!,
-                    parseResult.GetValue(outputOption),
-                    parseResult.GetValue(forceOption),
-                    parseResult.GetValue(allOption),
-                    parseResult.GetValue(acceptRevisionsOption),
-                    parseResult.GetValue(removeRsidInfoOption),
-                    parseResult.GetValue(removeMarkupForDocCompOption),
-                    parseResult.GetValue(removeCommentsOption),
-                    parseResult.GetValue(removeBookmarksOption),
-                    parseResult.GetValue(removeContentControlsOption),
-                    parseResult.GetValue(removeEndAndFootnotesOption),
-                    parseResult.GetValue(removeFieldCodesOption),
-                    parseResult.GetValue(removeGoBackBookmarkOption),
-                    parseResult.GetValue(removeHyperlinksOption),
-                    parseResult.GetValue(removeLastRenderedPageBreakOption),
-                    parseResult.GetValue(removePermissionsOption),
-                    parseResult.GetValue(removeProofOption),
-                    parseResult.GetValue(removeSmartTagsOption),
-                    parseResult.GetValue(removeSoftHyphensOption),
-                    parseResult.GetValue(removeWebHiddenOption),
-                    parseResult.GetValue(replaceTabsWithSpacesOption),
-                    parseResult.GetValue(normalizeXmlOption),
-                    parseResult.GetValue(formatOption),
-                    parseResult.GetValue(quietOption)
+                    new WordSimplifyMarkupOptions(
+                        parseResult.GetValue(inputArg)!,
+                        parseResult.GetValue(outputOption),
+                        parseResult.GetValue(forceOption),
+                        parseResult.GetValue(allOption),
+                        parseResult.GetValue(acceptRevisionsOption),
+                        parseResult.GetValue(removeRsidInfoOption),
+                        parseResult.GetValue(removeMarkupForDocCompOption),
+                        parseResult.GetValue(removeCommentsOption),
+                        parseResult.GetValue(removeBookmarksOption),
+                        parseResult.GetValue(removeContentControlsOption),
+                        parseResult.GetValue(removeEndAndFootnotesOption),
+                        parseResult.GetValue(removeFieldCodesOption),
+                        parseResult.GetValue(removeGoBackBookmarkOption),
+                        parseResult.GetValue(removeHyperlinksOption),
+                        parseResult.GetValue(removeLastRenderedPageBreakOption),
+                        parseResult.GetValue(removePermissionsOption),
+                        parseResult.GetValue(removeProofOption),
+                        parseResult.GetValue(removeSmartTagsOption),
+                        parseResult.GetValue(removeSoftHyphensOption),
+                        parseResult.GetValue(removeWebHiddenOption),
+                        parseResult.GetValue(replaceTabsWithSpacesOption),
+                        parseResult.GetValue(normalizeXmlOption),
+                        parseResult.GetValue(formatOption),
+                        parseResult.GetValue(quietOption)
+                    )
                 )
             )
         );
@@ -159,67 +161,19 @@ internal static class WordSimplifyMarkupCommand
         return cmd;
     }
 
-    private static int Run(
-        string inputPath,
-        string? outputPath,
-        bool force,
-        bool all,
-        bool acceptRevisions,
-        bool removeRsidInfo,
-        bool removeMarkupForDocComp,
-        bool removeComments,
-        bool removeBookmarks,
-        bool removeContentControls,
-        bool removeEndAndFootnotes,
-        bool removeFieldCodes,
-        bool removeGoBackBookmark,
-        bool removeHyperlinks,
-        bool removeLastRenderedPageBreak,
-        bool removePermissions,
-        bool removeProof,
-        bool removeSmartTags,
-        bool removeSoftHyphens,
-        bool removeWebHidden,
-        bool replaceTabsWithSpaces,
-        bool normalizeXml,
-        OutputFormat format,
-        bool quiet
-    )
+    private static int Run(WordSimplifyMarkupOptions options)
     {
-        var input = InputSource.From(inputPath, "stdin.docx");
+        var input = InputSource.From(options.InputPath, "stdin.docx");
         var defaultOutput = input.IsStdin
             ? "simplified.docx"
             : Path.Combine(
                 Path.GetDirectoryName(input.DisplayName)!,
                 $"{Path.GetFileNameWithoutExtension(input.DisplayName)}-simplified.docx"
             );
-        var output = OutputTarget.FromOption(outputPath, () => defaultOutput);
-        var writer = new OutputWriter(format, quiet || output.IsStdout);
+        var output = OutputTarget.FromOption(options.OutputPath, () => defaultOutput);
+        var writer = new OutputWriter(options.Format, options.Quiet || output.IsStdout);
 
-        var result = WordSimplifyMarkupService.Execute(
-            input,
-            output,
-            force,
-            all,
-            acceptRevisions,
-            removeRsidInfo,
-            removeMarkupForDocComp,
-            removeComments,
-            removeBookmarks,
-            removeContentControls,
-            removeEndAndFootnotes,
-            removeFieldCodes,
-            removeGoBackBookmark,
-            removeHyperlinks,
-            removeLastRenderedPageBreak,
-            removePermissions,
-            removeProof,
-            removeSmartTags,
-            removeSoftHyphens,
-            removeWebHidden,
-            replaceTabsWithSpaces,
-            normalizeXml
-        );
+        var result = WordSimplifyMarkupService.Execute(input, output, options);
 
         writer.WriteResult(result, CliJsonContext.Default.ConvertResult, ConvertResult.WriteText);
         return ExitCodes.Success;

--- a/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
+++ b/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupCommand.cs
@@ -14,6 +14,7 @@ internal static class WordSimplifyMarkupCommand
             Description =
                 "Output path for the simplified .docx. "
                 + "Defaults to <input>-simplified.docx (or simplified.docx when reading from stdin). Use '-' to write binary content to stdout.",
+        };
 
         var forceOption = new Option<bool>("--force")
         {

--- a/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupOptions.cs
+++ b/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupOptions.cs
@@ -1,0 +1,30 @@
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Word.SimplifyMarkup;
+
+internal sealed record WordSimplifyMarkupOptions(
+    string InputPath,
+    string? OutputPath,
+    bool Force,
+    bool All,
+    bool AcceptRevisions,
+    bool RemoveRsidInfo,
+    bool RemoveMarkupForDocComp,
+    bool RemoveComments,
+    bool RemoveBookmarks,
+    bool RemoveContentControls,
+    bool RemoveEndAndFootnotes,
+    bool RemoveFieldCodes,
+    bool RemoveGoBackBookmark,
+    bool RemoveHyperlinks,
+    bool RemoveLastRenderedPageBreak,
+    bool RemovePermissions,
+    bool RemoveProof,
+    bool RemoveSmartTags,
+    bool RemoveSoftHyphens,
+    bool RemoveWebHidden,
+    bool ReplaceTabsWithSpaces,
+    bool NormalizeXml,
+    OutputFormat Format,
+    bool Quiet
+);

--- a/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupService.cs
+++ b/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupService.cs
@@ -1,0 +1,161 @@
+using Clippit.Cli.Infrastructure;
+using Clippit.Word;
+
+namespace Clippit.Cli.Commands.Word.SimplifyMarkup;
+
+internal static class WordSimplifyMarkupService
+{
+    public static ConvertResult Execute(
+        InputSource input,
+        OutputTarget output,
+        bool force,
+        bool all,
+        bool acceptRevisions,
+        bool removeRsidInfo,
+        bool removeMarkupForDocComp,
+        bool removeComments,
+        bool removeBookmarks,
+        bool removeContentControls,
+        bool removeEndAndFootnotes,
+        bool removeFieldCodes,
+        bool removeGoBackBookmark,
+        bool removeHyperlinks,
+        bool removeLastRenderedPageBreak,
+        bool removePermissions,
+        bool removeProof,
+        bool removeSmartTags,
+        bool removeSoftHyphens,
+        bool removeWebHidden,
+        bool replaceTabsWithSpaces,
+        bool normalizeXml
+    )
+    {
+        var settings = new SimplifyMarkupSettings
+        {
+            AcceptRevisions = all || acceptRevisions,
+            RemoveRsidInfo = all || removeRsidInfo || removeMarkupForDocComp,
+            RemoveMarkupForDocumentComparison = all || removeMarkupForDocComp,
+            RemoveComments = all || removeComments,
+            RemoveBookmarks = all || removeBookmarks,
+            RemoveContentControls = all || removeContentControls,
+            RemoveEndAndFootNotes = all || removeEndAndFootnotes,
+            RemoveFieldCodes = all || removeFieldCodes,
+            RemoveGoBackBookmark = all || removeGoBackBookmark,
+            RemoveHyperlinks = all || removeHyperlinks,
+            RemoveLastRenderedPageBreak = all || removeLastRenderedPageBreak,
+            RemovePermissions = all || removePermissions,
+            RemoveProof = all || removeProof,
+            RemoveSmartTags = all || removeSmartTags,
+            RemoveSoftHyphens = all || removeSoftHyphens,
+            RemoveWebHidden = all || removeWebHidden,
+            ReplaceTabsWithSpaces = all || replaceTabsWithSpaces,
+            NormalizeXml = all || normalizeXml,
+        };
+
+        if (
+            !settings.AcceptRevisions
+            && !settings.RemoveMarkupForDocumentComparison
+            && !settings.RemoveRsidInfo
+            && !settings.RemoveComments
+            && !settings.RemoveBookmarks
+            && !settings.RemoveContentControls
+            && !settings.RemoveEndAndFootNotes
+            && !settings.RemoveFieldCodes
+            && !settings.RemoveGoBackBookmark
+            && !settings.RemoveHyperlinks
+            && !settings.RemoveLastRenderedPageBreak
+            && !settings.RemovePermissions
+            && !settings.RemoveProof
+            && !settings.RemoveSmartTags
+            && !settings.RemoveSoftHyphens
+            && !settings.RemoveWebHidden
+            && !settings.ReplaceTabsWithSpaces
+            && !settings.NormalizeXml
+        )
+        {
+            throw CliException.InvalidArguments(
+                "At least one simplification flag must be provided. Use --all to enable all cleanup options."
+            );
+        }
+
+        if (!output.IsStdout)
+        {
+            if (!input.IsStdin && PathsEqual(output.DisplayPath, input.DisplayName))
+                throw CliException.OutputError("Output path must not overwrite the input document.");
+        }
+
+        byte[] inputBytes;
+        using (var stream = input.OpenSeekable())
+        using (var memory = new MemoryStream())
+        {
+            stream.CopyTo(memory);
+            inputBytes = memory.ToArray();
+        }
+
+        WmlDocument simplified;
+        try
+        {
+            var wml = new WmlDocument(input.LogicalName, inputBytes);
+            simplified = MarkupSimplifier.SimplifyMarkup(wml, settings);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.InvalidFormat($"Could not process document: {ex.Message}");
+        }
+
+        string? tempPath = null;
+        Stream outputStream;
+        try
+        {
+            output.EnsureCanWrite(force, "output");
+            output.EnsureDirectoryExists();
+            outputStream = output.OpenWrite(out tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not open output for writing: {ex.Message}");
+        }
+
+        try
+        {
+            try
+            {
+                outputStream.Write(simplified.DocumentByteArray, 0, simplified.DocumentByteArray.Length);
+                outputStream.Flush();
+
+                if (output.IsStdout)
+                    output.Flush(outputStream);
+            }
+            finally
+            {
+                outputStream.Dispose();
+            }
+
+            if (!output.IsStdout)
+                output.Commit(tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not write output: {ex.Message}");
+        }
+        finally
+        {
+            OutputTarget.DeleteTemp(tempPath);
+        }
+
+        return new ConvertResult
+        {
+            Input = input.DisplayName,
+            Output = output.DisplayPath,
+            OutputSize = simplified.DocumentByteArray.Length,
+        };
+    }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), PathComparison);
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+}

--- a/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupService.cs
+++ b/Clippit.Cli/Commands/Word/SimplifyMarkup/WordSimplifyMarkupService.cs
@@ -5,51 +5,28 @@ namespace Clippit.Cli.Commands.Word.SimplifyMarkup;
 
 internal static class WordSimplifyMarkupService
 {
-    public static ConvertResult Execute(
-        InputSource input,
-        OutputTarget output,
-        bool force,
-        bool all,
-        bool acceptRevisions,
-        bool removeRsidInfo,
-        bool removeMarkupForDocComp,
-        bool removeComments,
-        bool removeBookmarks,
-        bool removeContentControls,
-        bool removeEndAndFootnotes,
-        bool removeFieldCodes,
-        bool removeGoBackBookmark,
-        bool removeHyperlinks,
-        bool removeLastRenderedPageBreak,
-        bool removePermissions,
-        bool removeProof,
-        bool removeSmartTags,
-        bool removeSoftHyphens,
-        bool removeWebHidden,
-        bool replaceTabsWithSpaces,
-        bool normalizeXml
-    )
+    public static ConvertResult Execute(InputSource input, OutputTarget output, WordSimplifyMarkupOptions options)
     {
         var settings = new SimplifyMarkupSettings
         {
-            AcceptRevisions = all || acceptRevisions,
-            RemoveRsidInfo = all || removeRsidInfo || removeMarkupForDocComp,
-            RemoveMarkupForDocumentComparison = all || removeMarkupForDocComp,
-            RemoveComments = all || removeComments,
-            RemoveBookmarks = all || removeBookmarks,
-            RemoveContentControls = all || removeContentControls,
-            RemoveEndAndFootNotes = all || removeEndAndFootnotes,
-            RemoveFieldCodes = all || removeFieldCodes,
-            RemoveGoBackBookmark = all || removeGoBackBookmark,
-            RemoveHyperlinks = all || removeHyperlinks,
-            RemoveLastRenderedPageBreak = all || removeLastRenderedPageBreak,
-            RemovePermissions = all || removePermissions,
-            RemoveProof = all || removeProof,
-            RemoveSmartTags = all || removeSmartTags,
-            RemoveSoftHyphens = all || removeSoftHyphens,
-            RemoveWebHidden = all || removeWebHidden,
-            ReplaceTabsWithSpaces = all || replaceTabsWithSpaces,
-            NormalizeXml = all || normalizeXml,
+            AcceptRevisions = options.All || options.AcceptRevisions,
+            RemoveRsidInfo = options.All || options.RemoveRsidInfo || options.RemoveMarkupForDocComp,
+            RemoveMarkupForDocumentComparison = options.All || options.RemoveMarkupForDocComp,
+            RemoveComments = options.All || options.RemoveComments,
+            RemoveBookmarks = options.All || options.RemoveBookmarks,
+            RemoveContentControls = options.All || options.RemoveContentControls,
+            RemoveEndAndFootNotes = options.All || options.RemoveEndAndFootnotes,
+            RemoveFieldCodes = options.All || options.RemoveFieldCodes,
+            RemoveGoBackBookmark = options.All || options.RemoveGoBackBookmark,
+            RemoveHyperlinks = options.All || options.RemoveHyperlinks,
+            RemoveLastRenderedPageBreak = options.All || options.RemoveLastRenderedPageBreak,
+            RemovePermissions = options.All || options.RemovePermissions,
+            RemoveProof = options.All || options.RemoveProof,
+            RemoveSmartTags = options.All || options.RemoveSmartTags,
+            RemoveSoftHyphens = options.All || options.RemoveSoftHyphens,
+            RemoveWebHidden = options.All || options.RemoveWebHidden,
+            ReplaceTabsWithSpaces = options.All || options.ReplaceTabsWithSpaces,
+            NormalizeXml = options.All || options.NormalizeXml,
         };
 
         if (
@@ -107,7 +84,7 @@ internal static class WordSimplifyMarkupService
         Stream outputStream;
         try
         {
-            output.EnsureCanWrite(force, "output");
+            output.EnsureCanWrite(options.Force, "output");
             output.EnsureDirectoryExists();
             outputStream = output.OpenWrite(out tempPath);
         }

--- a/Clippit.Cli/Commands/Word/WordCommand.cs
+++ b/Clippit.Cli/Commands/Word/WordCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using Clippit.Cli.Commands.Word.AcceptRevisions;
 using Clippit.Cli.Commands.Word.Compare;
 using Clippit.Cli.Commands.Word.FromHtml;
+using Clippit.Cli.Commands.Word.SimplifyMarkup;
 using Clippit.Cli.Commands.Word.ToHtml;
 using Clippit.Cli.Commands.Word.Verify;
 
@@ -17,6 +18,7 @@ internal static class WordCommand
         var cmd = new Command("word", "Work with Word (.docx) files");
         cmd.Subcommands.Add(WordAcceptRevisionsCommand.Build());
         cmd.Subcommands.Add(WordCompareCommand.Build());
+        cmd.Subcommands.Add(WordSimplifyMarkupCommand.Build());
         cmd.Subcommands.Add(WordVerifyCommand.Build());
         cmd.Subcommands.Add(WordToHtmlCommand.Build());
         cmd.Subcommands.Add(WordFromHtmlCommand.Build());

--- a/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
@@ -356,7 +356,8 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
         using var stream = docEntry!.Open();
         using var reader = new StreamReader(stream, Encoding.UTF8);
         var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
-        // Tab character elements (<w:tab/> with no attributes, inside runs) must be gone
+        // Tab character elements must be replaced; the self-closing <w:tab/> form
+        // (no attributes) is what appears inside runs and is what the simplifier removes.
         await Assert.That(xmlContent).DoesNotContain("<w:tab/>");
 
         using var doc = WordprocessingDocument.Open(output.FullName, false);

--- a/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
@@ -11,7 +11,7 @@ namespace Clippit.Tests.Cli.Integration.Word;
 internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
 {
     [Test]
-    public async Task CLI118_WordSimplifyMarkup_NoFlags_ReturnsInvalidArguments()
+    public async Task CLI141_WordSimplifyMarkup_NoFlags_ReturnsInvalidArguments()
     {
         var input = CliTestRunner.TestFile("DB007-Spec.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-no-flags");
@@ -27,7 +27,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI119_WordSimplifyMarkup_AllFlag_ProducesValidDocx()
+    public async Task CLI142_WordSimplifyMarkup_AllFlag_ProducesValidDocx()
     {
         var input = CliTestRunner.TestFile("DB007-Spec.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-all");
@@ -61,7 +61,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI120_WordSimplifyMarkup_AcceptRevisions_RemovesTrackedChanges()
+    public async Task CLI143_WordSimplifyMarkup_AcceptRevisions_RemovesTrackedChanges()
     {
         var input = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-accept-revisions");
@@ -92,7 +92,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI121_WordSimplifyMarkup_RemoveRsidInfo_EliminatesRsidAttributes()
+    public async Task CLI144_WordSimplifyMarkup_RemoveRsidInfo_EliminatesRsidAttributes()
     {
         var input = CliTestRunner.TestFile("DB007-Spec.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-rsid");
@@ -133,7 +133,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI122_WordSimplifyMarkup_DefaultOutputPath_DerivedFromInput()
+    public async Task CLI145_WordSimplifyMarkup_DefaultOutputPath_DerivedFromInput()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-default-output");
         var source = CliTestRunner.TestFile("DB007-Spec.docx");
@@ -155,7 +155,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI123_WordSimplifyMarkup_QuietSuppressesStdout()
+    public async Task CLI146_WordSimplifyMarkup_QuietSuppressesStdout()
     {
         var input = CliTestRunner.TestFile("DB007-Spec.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-quiet");
@@ -180,7 +180,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI124_WordSimplifyMarkup_InvalidInput_ReturnsInvalidFormat()
+    public async Task CLI147_WordSimplifyMarkup_InvalidInput_ReturnsInvalidFormat()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-invalid-input");
         var badInput = new FileInfo(Path.Combine(tempDir.FullName, "not-a-docx.docx"));
@@ -206,7 +206,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI125_WordSimplifyMarkup_OutputToStdout_StreamsBinaryDocx()
+    public async Task CLI148_WordSimplifyMarkup_OutputToStdout_StreamsBinaryDocx()
     {
         var input = CliTestRunner.TestFile("DB007-Spec.docx");
         var inputBytes = await File.ReadAllBytesAsync(input.FullName).ConfigureAwait(false);
@@ -230,7 +230,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI126_WordSimplifyMarkup_RemoveBookmarks_EliminatesBookmarkElements()
+    public async Task CLI149_WordSimplifyMarkup_RemoveBookmarks_EliminatesBookmarkElements()
     {
         var input = CliTestRunner.TestFile("DB007-Spec.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-bookmarks");
@@ -264,7 +264,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI127_WordSimplifyMarkup_RemoveContentControls_EliminatesSdtElements()
+    public async Task CLI150_WordSimplifyMarkup_RemoveContentControls_EliminatesSdtElements()
     {
         var input = CliTestRunner.TestFile("HC030-Content-Controls.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-content-controls");
@@ -298,7 +298,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI128_WordSimplifyMarkup_RemoveHyperlinks_EliminatesHyperlinkElements()
+    public async Task CLI151_WordSimplifyMarkup_RemoveHyperlinks_EliminatesHyperlinkElements()
     {
         var input = CliTestRunner.TestFile("HC023-Hyperlink.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-hyperlinks");
@@ -332,7 +332,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI129_WordSimplifyMarkup_ReplaceTabsWithSpaces_RemovesTabCharacterElements()
+    public async Task CLI152_WordSimplifyMarkup_ReplaceTabsWithSpaces_RemovesTabCharacterElements()
     {
         var input = CliTestRunner.TestFile("HC024-Tabs-01.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-replace-tabs");
@@ -368,7 +368,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI130_WordSimplifyMarkup_RemoveFieldCodes_EliminatesInstrTextElements()
+    public async Task CLI153_WordSimplifyMarkup_RemoveFieldCodes_EliminatesInstrTextElements()
     {
         var input = CliTestRunner.TestFile("HC040-Hyperlink-Fieldcode-01.docx");
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-field-codes");
@@ -402,7 +402,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI131_WordSimplifyMarkup_RemoveGoBackBookmark_RemovesOnlyGoBackBookmark()
+    public async Task CLI154_WordSimplifyMarkup_RemoveGoBackBookmark_RemovesOnlyGoBackBookmark()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-go-back-bookmark");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -445,7 +445,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI132_WordSimplifyMarkup_RemoveMarkupForDocumentComparison_RemovesRsidAttributes()
+    public async Task CLI155_WordSimplifyMarkup_RemoveMarkupForDocumentComparison_RemovesRsidAttributes()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-markup-for-document-comparison");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -489,7 +489,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI133_WordSimplifyMarkup_RemoveComments_RemovesCommentMarkup()
+    public async Task CLI156_WordSimplifyMarkup_RemoveComments_RemovesCommentMarkup()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-comments");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -541,7 +541,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI134_WordSimplifyMarkup_RemoveEndAndFootnotes_RemovesNoteReferences()
+    public async Task CLI157_WordSimplifyMarkup_RemoveEndAndFootnotes_RemovesNoteReferences()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-end-and-footnotes");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -581,7 +581,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI135_WordSimplifyMarkup_RemoveLastRenderedPageBreak_RemovesElement()
+    public async Task CLI158_WordSimplifyMarkup_RemoveLastRenderedPageBreak_RemovesElement()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-last-rendered-page-break");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -618,7 +618,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI136_WordSimplifyMarkup_RemovePermissions_RemovesPermissionMarkup()
+    public async Task CLI159_WordSimplifyMarkup_RemovePermissions_RemovesPermissionMarkup()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-permissions");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -658,7 +658,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI137_WordSimplifyMarkup_RemoveProof_RemovesProofErrElements()
+    public async Task CLI160_WordSimplifyMarkup_RemoveProof_RemovesProofErrElements()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-proof");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -690,7 +690,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI138_WordSimplifyMarkup_RemoveSmartTags_RemovesSmartTagWrappers()
+    public async Task CLI161_WordSimplifyMarkup_RemoveSmartTags_RemovesSmartTagWrappers()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-smart-tags");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -729,7 +729,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI139_WordSimplifyMarkup_RemoveSoftHyphens_RemovesSoftHyphenElements()
+    public async Task CLI162_WordSimplifyMarkup_RemoveSoftHyphens_RemovesSoftHyphenElements()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-soft-hyphens");
         var input = await CreateDocxWithMainDocumentXmlAsync(
@@ -770,7 +770,7 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI140_WordSimplifyMarkup_RemoveWebHidden_RemovesWebHiddenElement()
+    public async Task CLI163_WordSimplifyMarkup_RemoveWebHidden_RemovesWebHiddenElement()
     {
         var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-web-hidden");
         var input = await CreateDocxWithMainDocumentXmlAsync(

--- a/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
@@ -1,0 +1,215 @@
+using System.IO.Compression;
+using System.Text;
+using Clippit.Word;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Tests.Cli.Integration.Word;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
+{
+    [Test]
+    public async Task CLI118_WordSimplifyMarkup_NoFlags_ReturnsInvalidArguments()
+    {
+        var input = CliTestRunner.TestFile("DB007-Spec.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-no-flags");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "simplify-markup", input.FullName, "--output", output.FullName)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(2);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("INVALID_ARGUMENTS");
+    }
+
+    [Test]
+    public async Task CLI119_WordSimplifyMarkup_AllFlag_ProducesValidDocx()
+    {
+        var input = CliTestRunner.TestFile("DB007-Spec.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-all");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--all",
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo(input.FullName);
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(output.FullName);
+        await Assert.That(json.RootElement.GetProperty("outputSize").GetInt64()).IsGreaterThan(0);
+        await Assert.That(output.Exists).IsTrue();
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await ValidateRelationships(doc);
+        await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI120_WordSimplifyMarkup_AcceptRevisions_RemovesTrackedChanges()
+    {
+        var input = CliTestRunner.TestFile("RA001-Tracked-Revisions-01.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-accept-revisions");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "clean.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--accept-revisions",
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Assert.That(RevisionAccepter.HasTrackedRevisions(doc)).IsFalse();
+        await ValidateRelationships(doc);
+    }
+
+    [Test]
+    public async Task CLI121_WordSimplifyMarkup_RemoveRsidInfo_EliminatesRsidAttributes()
+    {
+        var input = CliTestRunner.TestFile("DB007-Spec.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-rsid");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-rsid-info",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+
+        // Verify no rsid attributes remain in document.xml
+        using var zip = ZipFile.OpenRead(output.FullName);
+        var docEntry = zip.GetEntry("word/document.xml");
+        await Assert.That(docEntry).IsNotNull();
+
+        using var stream = docEntry!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+        await Assert.That(xmlContent).DoesNotContain(":rsid");
+    }
+
+    [Test]
+    public async Task CLI122_WordSimplifyMarkup_DefaultOutputPath_DerivedFromInput()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-default-output");
+        var source = CliTestRunner.TestFile("DB007-Spec.docx");
+        var localInput = new FileInfo(Path.Combine(tempDir.FullName, "DB007-Spec.docx"));
+        File.Copy(source.FullName, localInput.FullName);
+
+        var expectedOutput = new FileInfo(Path.Combine(tempDir.FullName, "DB007-Spec-simplified.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "simplify-markup", localInput.FullName, "--remove-rsid-info", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(expectedOutput.FullName);
+        await Assert.That(expectedOutput.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI123_WordSimplifyMarkup_QuietSuppressesStdout()
+    {
+        var input = CliTestRunner.TestFile("DB007-Spec.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-quiet");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-rsid-info",
+                "--output",
+                output.FullName,
+                "--quiet"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI124_WordSimplifyMarkup_InvalidInput_ReturnsInvalidFormat()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-invalid-input");
+        var badInput = new FileInfo(Path.Combine(tempDir.FullName, "not-a-docx.docx"));
+        await File.WriteAllTextAsync(badInput.FullName, "not a valid DOCX").ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                badInput.FullName,
+                "--all",
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("INVALID_FORMAT");
+    }
+
+    [Test]
+    public async Task CLI125_WordSimplifyMarkup_OutputToStdout_StreamsBinaryDocx()
+    {
+        var input = CliTestRunner.TestFile("DB007-Spec.docx");
+        var inputBytes = await File.ReadAllBytesAsync(input.FullName).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(inputBytes, "word", "simplify-markup", "-", "--all", "--output", "-")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        // Output should be a DOCX (ZIP/PK header)
+        await Assert.That(result.StandardOutput.Length).IsGreaterThan(0);
+        await Assert.That(result.StandardOutput[0]).IsEqualTo((byte)'P');
+        await Assert.That(result.StandardOutput[1]).IsEqualTo((byte)'K');
+    }
+}
+#pragma warning restore CA1707

--- a/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
@@ -85,6 +85,8 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
         using var doc = WordprocessingDocument.Open(output.FullName, false);
         await Assert.That(RevisionAccepter.HasTrackedRevisions(doc)).IsFalse();
         await ValidateRelationships(doc);
+        // Full schema validation is intentionally omitted here: RA001-Tracked-Revisions-01.docx
+        // contains pre-existing schema errors unrelated to revision acceptance.
     }
 
     [Test]
@@ -118,6 +120,14 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
         using var reader = new StreamReader(stream, Encoding.UTF8);
         var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
         await Assert.That(xmlContent).DoesNotContain(":rsid");
+
+        // Verify the w:rsids element is also removed from word/settings.xml
+        var settingsEntry = zip.GetEntry("word/settings.xml");
+        await Assert.That(settingsEntry).IsNotNull();
+        using var settingsStream = settingsEntry!.Open();
+        using var settingsReader = new StreamReader(settingsStream, Encoding.UTF8);
+        var settingsContent = await settingsReader.ReadToEndAsync().ConfigureAwait(false);
+        await Assert.That(settingsContent).DoesNotContain("w:rsids");
     }
 
     [Test]
@@ -206,10 +216,186 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
         await Assert.That(result.ExitCode).IsEqualTo(0);
         await Assert.That(result.StandardError).IsEmpty();
 
-        // Output should be a DOCX (ZIP/PK header)
+        // Output should be a valid DOCX, not just a ZIP/PK header
         await Assert.That(result.StandardOutput.Length).IsGreaterThan(0);
         await Assert.That(result.StandardOutput[0]).IsEqualTo((byte)'P');
         await Assert.That(result.StandardOutput[1]).IsEqualTo((byte)'K');
+
+        using var ms = new MemoryStream(result.StandardOutput);
+        using var doc = WordprocessingDocument.Open(ms, false);
+        await ValidateRelationships(doc);
+        await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI126_WordSimplifyMarkup_RemoveBookmarks_EliminatesBookmarkElements()
+    {
+        var input = CliTestRunner.TestFile("DB007-Spec.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-bookmarks");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-bookmarks",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var zip = ZipFile.OpenRead(output.FullName);
+        var docEntry = zip.GetEntry("word/document.xml");
+        await Assert.That(docEntry).IsNotNull();
+        using var stream = docEntry!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+        await Assert.That(xmlContent).DoesNotContain("w:bookmarkStart");
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await ValidateRelationships(doc);
+        await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI127_WordSimplifyMarkup_RemoveContentControls_EliminatesSdtElements()
+    {
+        var input = CliTestRunner.TestFile("HC030-Content-Controls.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-content-controls");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-content-controls",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var zip = ZipFile.OpenRead(output.FullName);
+        var docEntry = zip.GetEntry("word/document.xml");
+        await Assert.That(docEntry).IsNotNull();
+        using var stream = docEntry!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+        await Assert.That(xmlContent).DoesNotContain("w:sdt");
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await ValidateRelationships(doc);
+        await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI128_WordSimplifyMarkup_RemoveHyperlinks_EliminatesHyperlinkElements()
+    {
+        var input = CliTestRunner.TestFile("HC023-Hyperlink.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-hyperlinks");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-hyperlinks",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var zip = ZipFile.OpenRead(output.FullName);
+        var docEntry = zip.GetEntry("word/document.xml");
+        await Assert.That(docEntry).IsNotNull();
+        using var stream = docEntry!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+        await Assert.That(xmlContent).DoesNotContain("w:hyperlink");
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await ValidateRelationships(doc);
+        await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI129_WordSimplifyMarkup_ReplaceTabsWithSpaces_RemovesTabCharacterElements()
+    {
+        var input = CliTestRunner.TestFile("HC024-Tabs-01.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-replace-tabs");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--replace-tabs-with-spaces",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var zip = ZipFile.OpenRead(output.FullName);
+        var docEntry = zip.GetEntry("word/document.xml");
+        await Assert.That(docEntry).IsNotNull();
+        using var stream = docEntry!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+        // Tab character elements (<w:tab/> with no attributes, inside runs) must be gone
+        await Assert.That(xmlContent).DoesNotContain("<w:tab/>");
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await ValidateRelationships(doc);
+        await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI130_WordSimplifyMarkup_RemoveFieldCodes_EliminatesInstrTextElements()
+    {
+        var input = CliTestRunner.TestFile("HC040-Hyperlink-Fieldcode-01.docx");
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-field-codes");
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-field-codes",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var zip = ZipFile.OpenRead(output.FullName);
+        var docEntry = zip.GetEntry("word/document.xml");
+        await Assert.That(docEntry).IsNotNull();
+        using var stream = docEntry!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+        await Assert.That(xmlContent).DoesNotContain("w:instrText");
+
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await ValidateRelationships(doc);
+        await Validate(doc);
     }
 }
 #pragma warning restore CA1707

--- a/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordSimplifyMarkupTests.cs
@@ -1,6 +1,8 @@
 using System.IO.Compression;
 using System.Text;
+using System.Xml.Linq;
 using Clippit.Word;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 
 namespace Clippit.Tests.Cli.Integration.Word;
@@ -356,9 +358,9 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
         using var stream = docEntry!.Open();
         using var reader = new StreamReader(stream, Encoding.UTF8);
         var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
-        // Tab character elements must be replaced; the self-closing <w:tab/> form
-        // (no attributes) is what appears inside runs and is what the simplifier removes.
-        await Assert.That(xmlContent).DoesNotContain("<w:tab/>");
+        var docXml = XDocument.Parse(xmlContent);
+        var runTabElements = docXml.Descendants(W.r).Elements(W.tab).ToList();
+        await Assert.That(runTabElements).IsEmpty();
 
         using var doc = WordprocessingDocument.Open(output.FullName, false);
         await ValidateRelationships(doc);
@@ -397,6 +399,451 @@ internal sealed class WordSimplifyMarkupTests : CliIntegrationTestBase
         using var doc = WordprocessingDocument.Open(output.FullName, false);
         await ValidateRelationships(doc);
         await Validate(doc);
+    }
+
+    [Test]
+    public async Task CLI131_WordSimplifyMarkup_RemoveGoBackBookmark_RemovesOnlyGoBackBookmark()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-go-back-bookmark");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:bookmarkStart w:id="0" w:name="_GoBack"/>
+                  <w:bookmarkEnd w:id="0"/>
+                  <w:bookmarkStart w:id="1" w:name="KeepMe"/>
+                  <w:r><w:t>Text</w:t></w:r>
+                  <w:bookmarkEnd w:id="1"/>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-go-back-bookmark",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        var bookmarkStarts = docXml.Descendants(W.bookmarkStart).Select(x => (string?)x.Attribute(W.name)).ToList();
+        await Assert.That(bookmarkStarts).Contains("KeepMe");
+        await Assert.That(bookmarkStarts).DoesNotContain("_GoBack");
+    }
+
+    [Test]
+    public async Task CLI132_WordSimplifyMarkup_RemoveMarkupForDocumentComparison_RemovesRsidAttributes()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-markup-for-document-comparison");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p w:rsidR="001234AB" w:rsidRDefault="001234AB">
+                  <w:r w:rsidRPr="00AB1234">
+                    <w:t>Hello</w:t>
+                  </w:r>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-markup-for-document-comparison",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        var rsidAttributes = docXml
+            .Descendants()
+            .SelectMany(e => e.Attributes())
+            .Where(a => a.Name.Namespace == W.rsidR.Namespace && a.Name.LocalName.StartsWith("rsid"))
+            .ToList();
+        await Assert.That(rsidAttributes).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI133_WordSimplifyMarkup_RemoveComments_RemovesCommentMarkup()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-comments");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:commentRangeStart w:id="1"/>
+                  <w:r><w:t>Hello</w:t></w:r>
+                  <w:commentRangeEnd w:id="1"/>
+                  <w:r>
+                    <w:rPr><w:rStyle w:val="CommentReference"/></w:rPr>
+                    <w:commentReference w:id="1"/>
+                  </w:r>
+                </w:p>
+              </w:body>
+            </w:document>
+            """,
+            commentsXml: """
+            <w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:comment w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">
+                <w:p><w:r><w:t>Comment</w:t></w:r></w:p>
+              </w:comment>
+            </w:comments>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-comments",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.commentRangeStart)).IsEmpty();
+        await Assert.That(docXml.Descendants(W.commentRangeEnd)).IsEmpty();
+        await Assert.That(docXml.Descendants(W.commentReference)).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI134_WordSimplifyMarkup_RemoveEndAndFootnotes_RemovesNoteReferences()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-end-and-footnotes");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:r><w:t xml:space="preserve">Some text</w:t></w:r>
+                  <w:r><w:footnoteReference w:id="1"/></w:r>
+                  <w:r><w:endnoteReference w:id="1"/></w:r>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-end-and-footnotes",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.footnoteReference)).IsEmpty();
+        await Assert.That(docXml.Descendants(W.endnoteReference)).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI135_WordSimplifyMarkup_RemoveLastRenderedPageBreak_RemovesElement()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-last-rendered-page-break");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:r><w:lastRenderedPageBreak/><w:t>Text</w:t></w:r>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-last-rendered-page-break",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.lastRenderedPageBreak)).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI136_WordSimplifyMarkup_RemovePermissions_RemovesPermissionMarkup()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-permissions");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:permStart w:id="1" w:edGrp="everyone"/>
+                  <w:r><w:t>Protected text</w:t></w:r>
+                  <w:permEnd w:id="1"/>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-permissions",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.permStart)).IsEmpty();
+        await Assert.That(docXml.Descendants(W.permEnd)).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI137_WordSimplifyMarkup_RemoveProof_RemovesProofErrElements()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-proof");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:proofErr w:type="spellStart"/>
+                  <w:r><w:t>mispelled</w:t></w:r>
+                  <w:proofErr w:type="spellEnd"/>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "simplify-markup", input.FullName, "--remove-proof", "--output", output.FullName)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.proofErr)).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI138_WordSimplifyMarkup_RemoveSmartTags_RemovesSmartTagWrappers()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-smart-tags");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:smartTag w:uri="urn:schemas-microsoft-com:office:smarttags" w:element="country-region">
+                    <w:r><w:t>Algeria</w:t></w:r>
+                  </w:smartTag>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-smart-tags",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.smartTag)).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI139_WordSimplifyMarkup_RemoveSoftHyphens_RemovesSoftHyphenElements()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-soft-hyphens");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:r>
+                    <w:t xml:space="preserve">extra</w:t>
+                    <w:softHyphen/>
+                    <w:t>ordinary</w:t>
+                  </w:r>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-soft-hyphens",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.softHyphen)).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI140_WordSimplifyMarkup_RemoveWebHidden_RemovesWebHiddenElement()
+    {
+        var tempDir = CliTestRunner.CreateTempDirectory("simplify-remove-web-hidden");
+        var input = await CreateDocxWithMainDocumentXmlAsync(
+            tempDir,
+            "in.docx",
+            """
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body>
+                <w:p>
+                  <w:r>
+                    <w:rPr><w:webHidden/></w:rPr>
+                    <w:t>Hidden on web</w:t>
+                  </w:r>
+                </w:p>
+              </w:body>
+            </w:document>
+            """
+        );
+        var output = new FileInfo(Path.Combine(tempDir.FullName, "out.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "simplify-markup",
+                input.FullName,
+                "--remove-web-hidden",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        var docXml = await ReadPartXmlAsync(output, "word/document.xml");
+        await Assert.That(docXml.Descendants(W.webHidden)).IsEmpty();
+    }
+
+    private static async Task<FileInfo> CreateDocxWithMainDocumentXmlAsync(
+        DirectoryInfo directory,
+        string fileName,
+        string mainDocumentXml,
+        string? commentsXml = null
+    )
+    {
+        var path = Path.Combine(directory.FullName, fileName);
+
+        await using (var file = File.Create(path))
+        using (var doc = WordprocessingDocument.Create(file, WordprocessingDocumentType.Document))
+        {
+            var mainPart = doc.AddMainDocumentPart();
+            mainPart.PutXDocument(XDocument.Parse(mainDocumentXml));
+
+            if (commentsXml is not null)
+            {
+                var commentsPart = mainPart.AddNewPart<WordprocessingCommentsPart>();
+                commentsPart.PutXDocument(XDocument.Parse(commentsXml));
+            }
+        }
+
+        return new FileInfo(path);
+    }
+
+    private static async Task<XDocument> ReadPartXmlAsync(FileInfo docxFile, string partPath)
+    {
+        using var zip = ZipFile.OpenRead(docxFile.FullName);
+        var partEntry = zip.GetEntry(partPath);
+        await Assert.That(partEntry).IsNotNull();
+
+        using var stream = partEntry!.Open();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var xmlContent = await reader.ReadToEndAsync().ConfigureAwait(false);
+        return XDocument.Parse(xmlContent);
     }
 }
 #pragma warning restore CA1707

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -15,7 +15,7 @@ published for documentation, integration validation, and contract tests.
 | [`build-result.v1.json`](./build-result.v1.json)       | Stdout payload of `clippit pptx build run` (JSON mode)       |
 | [`verify-result.v1.json`](./verify-result.v1.json)     | Stdout payload of `clippit pptx verify`, `clippit word verify`, `clippit excel verify` (JSON mode) |
 | [`compare-result.v1.json`](./compare-result.v1.json)   | Stdout payload of `clippit word compare` (JSON mode)          |
-| [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, `clippit word accept-revisions`, or `clippit excel to-html` (JSON mode) |
+| [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, `clippit word accept-revisions`, `clippit word simplify-markup`, or `clippit excel to-html` (JSON mode) |
 
 ## Output discipline
 


### PR DESCRIPTION
Implements issue #377. Exposes MarkupSimplifier.SimplifyMarkup as a CLI
command with one flag per SimplifyMarkupSettings field plus a convenience
--all preset.

New command: clippit word simplify-markup <input> [options]
  - --all: enable every cleanup option
  - --accept-revisions
  - --remove-rsid-info
  - --remove-markup-for-document-comparison
  - --remove-comments, --remove-bookmarks, --remove-content-controls
  - --remove-end-and-footnotes, --remove-field-codes
  - --remove-go-back-bookmark, --remove-hyperlinks
  - --remove-last-rendered-page-break, --remove-permissions
  - --remove-proof, --remove-smart-tags, --remove-soft-hyphens
  - --remove-web-hidden, --replace-tabs-with-spaces, --normalize-xml
  - --output / -o, --force, --format json|text, --quiet
  - stdin support: use '-' as input, '--output -' for stdout

Result payload reuses ConvertResult (input, output, outputSize).
Documented in docs/schemas/README.md.

8 integration tests (CLI118–CLI125):
- No-flags returns INVALID_ARGUMENTS (exit 2)
- --all produces valid DOCX with full Validate()
- --accept-revisions removes tracked revisions
- --remove-rsid-info eliminates rsid attributes
- Default output naming as <name>-simplified.docx
- --quiet suppresses stdout
- Invalid input returns INVALID_FORMAT (exit 4)
- --output - streams binary DOCX to stdout

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
