### PR TITLE
Split CLI docs into focused Word/Excel/PPTX pages

### DIFF
--- a/docs/cli-excel.md
+++ b/docs/cli-excel.md
@@ -1,0 +1,65 @@
+# Excel CLI (`excel`)
+
+Use this page for Excel (`.xlsx`) command reference.
+
+- Back to [CLI start page](cli.md)
+- Shared verify diagnostics schema: [schemas/README.md](schemas/README.md)
+
+## Commands at a glance
+
+| Command | Purpose |
+| --- | --- |
+| `clippit excel verify` | Validate package/schema/relationships |
+| `clippit excel to-html` | Convert workbook range/sheet/table to HTML/CSS |
+
+All commands support `--format json|text` and `--quiet`.
+
+## `excel verify`
+
+Validate readability and Open XML structure of a spreadsheet.
+
+```text
+clippit excel verify <input.xlsx|-> [--office-version <version>] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--office-version` | Open XML schema version (default: `Microsoft365`). |
+
+Readable-but-invalid spreadsheets return verify JSON and exit code `4`.
+
+```bash
+clippit excel verify spreadsheet.xlsx --format json
+```
+
+```json
+{"input":"/work/spreadsheet.xlsx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
+```
+
+## `excel to-html`
+
+Convert a worksheet, range, or defined table to HTML/CSS.
+
+```text
+clippit excel to-html <input.xlsx|-> [--output <file.html|->] [--sheet <name>] [--range <A1:D10>] [--table <name>] [--page-title <text>] [--additional-css <css>] [--css-prefix <prefix>] [--no-fabricate-css] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output HTML path (default: `<input>.html`). Use `-` for stdout. |
+| `--sheet` | Sheet name. Defaults to first sheet if `--range` and `--table` are omitted. |
+| `--range` | Cell/range coordinates (for example `A1:D10`). Requires `--sheet`. |
+| `--table` | Defined Excel table name. Cannot be combined with `--sheet` or `--range`. |
+| `--page-title` | HTML `<title>` text. |
+| `--additional-css` | Extra CSS injected into generated `<style>`. |
+| `--css-prefix` | Prefix for generated CSS classes (default: `pt-`). |
+| `--no-fabricate-css` | Use inline styles instead of generated CSS classes. |
+
+```bash
+clippit excel to-html spreadsheet.xlsx --sheet "Q3 Data" --range "B2:F15" --output sheet.html --format json
+```
+
+```json
+{"input":"/work/spreadsheet.xlsx","output":"/work/sheet.html","outputSize":18231}
+```
+

--- a/docs/cli-pptx.md
+++ b/docs/cli-pptx.md
@@ -1,0 +1,127 @@
+# PowerPoint CLI (`pptx`)
+
+Use this page for PowerPoint automation commands.
+
+- Back to [CLI start page](cli.md)
+- Schemas and diagnostic kinds: [schemas/README.md](schemas/README.md)
+
+## Commands at a glance
+
+| Command | Purpose |
+| --- | --- |
+| `clippit pptx split` | Split a deck into single-slide `.pptx` files |
+| `clippit pptx build init` | Scaffold a deck manifest |
+| `clippit pptx build run` | Build a final deck from a manifest |
+| `clippit pptx verify` | Validate package/schema/relationships |
+
+All commands support `--format json|text` and `--quiet`.
+
+## `pptx split`
+
+Split a `.pptx` file into single-slide presentations.
+
+```text
+clippit pptx split <input.pptx|-> [--output <dir>] [--slides <expr>] [--manifest] [--force] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output directory (default: source directory, or current directory for stdin). |
+| `--slides`, `-s` | 1-based slide numbers/ranges like `1,3,6-9` (default: all slides). |
+| `--manifest` | Also write a `pptx build run` compatible manifest. |
+| `--force` | Overwrite existing output files. |
+
+```bash
+clippit pptx split deck.pptx --output slides --manifest
+```
+
+```json
+{"input":"/work/deck.pptx","outputDir":"/work/slides","manifest":"/work/slides/deck.manifest.json","count":2,"slides":[{"index":1,"file":"/work/slides/deck-001.pptx","title":"Intro"},{"index":3,"file":"/work/slides/deck-003.pptx","title":null}]}
+```
+
+## `pptx build init`
+
+Create an empty deck manifest.
+
+```text
+clippit pptx build init [--output <manifest.json|->] [--force] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Manifest path (default: `./clippit-deck.json`). Use `-` for stdout. |
+| `--force` | Overwrite existing manifest file. |
+
+```bash
+clippit pptx build init --output deck.json
+```
+
+Minimal manifest:
+
+```json
+{
+  "$schema": "https://sergey-tihon.github.io/Clippit/schemas/deck-manifest.v1.json",
+  "title": "Conference Deck",
+  "output": "final.pptx",
+  "deck": [
+    { "section": "Opening" },
+    "intro.pptx",
+    { "file": "demo.pptx", "keepSections": true }
+  ]
+}
+```
+
+Manifest rules:
+
+| Property | Required | Notes |
+| --- | --- | --- |
+| `title` | Yes | Output presentation title metadata. |
+| `output` | Yes | Relative to manifest directory. |
+| `deck` | Yes | Ordered entries; at least one entry. |
+| string entry | No | `[Section Name]` means section divider; otherwise source `.pptx` path. |
+| `{ "section": "Name" }` | No | Explicit section divider. |
+| `{ "file": "deck.pptx" }` | No | Source deck entry; optional `masters`, `slides`, `keepSections`. |
+
+## `pptx build run`
+
+Build a final `.pptx` from a manifest.
+
+```text
+clippit pptx build run <manifest.json|-> [--output <file.pptx|->] [--force] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Override output path. Use `-` for binary stdout stream. |
+| `--force` | Overwrite existing output file. |
+
+```bash
+clippit pptx build run deck.json --output final.pptx --force
+```
+
+```json
+{"output":"/work/final.pptx","totalSlides":12,"entries":[{"section":"Opening"},{"file":"intro.pptx","slides":3},{"file":"demo.pptx","slides":9}]}
+```
+
+## `pptx verify`
+
+Validate readability and Open XML structure of a `.pptx` file.
+
+```text
+clippit pptx verify <input.pptx|-> [--office-version <version>] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--office-version` | Open XML schema version (default: `Microsoft365`). |
+
+If the deck is readable but has validation diagnostics, output is still emitted and process exits with code `4`.
+
+```bash
+clippit pptx verify deck.pptx --format json
+```
+
+```json
+{"input":"/work/deck.pptx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
+```
+

--- a/docs/cli-word.md
+++ b/docs/cli-word.md
@@ -1,0 +1,159 @@
+# Word CLI (`word`)
+
+Use this page for Word (`.docx`) command reference.
+
+- Back to [CLI start page](cli.md)
+- Shared verify diagnostics schema: [schemas/README.md](schemas/README.md)
+
+## Commands at a glance
+
+| Command | Purpose |
+| --- | --- |
+| `clippit word verify` | Validate package/schema/relationships |
+| `clippit word compare` | Compare two docs and emit tracked revisions |
+| `clippit word assemble` | Fill a template with XML data |
+| `clippit word accept-revisions` | Accept all revisions in a document |
+| `clippit word to-html` | Convert DOCX to HTML/CSS |
+| `clippit word from-html` | Convert HTML/CSS to DOCX |
+
+All commands support `--format json|text` and `--quiet`.
+
+## `word verify`
+
+```text
+clippit word verify <input.docx|-> [--office-version <version>] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--office-version` | Open XML schema version (default: `Microsoft365`). |
+
+Readable-but-invalid documents return verify JSON and exit code `4`.
+
+```bash
+clippit word verify document.docx --format json
+```
+
+```json
+{"input":"/work/document.docx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
+```
+
+## `word compare`
+
+Compare two `.docx` files and write a tracked-revisions result document.
+
+```text
+clippit word compare <source.docx|-> <revised.docx|-> [--output <file.docx|->] [--author <text>] [--date-time <text>] [--case-insensitive] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output compared doc path (default: `<source>-compared.docx`). Use `-` for stdout. |
+| `--author` | Author for generated revisions. |
+| `--date-time` | Date/time for generated revisions. |
+| `--case-insensitive` | Ignore case when comparing words. |
+
+```bash
+clippit word compare before.docx after.docx --output compared.docx --format json
+```
+
+```json
+{"source":"/work/before.docx","revised":"/work/after.docx","output":"/work/compared.docx","outputSize":59321,"revisions":8,"authorForRevisions":"Jane Doe","dateTimeForRevisions":"2026-01-01T00:00:00Z","caseInsensitive":false}
+```
+
+## `word assemble`
+
+Assemble a `.docx` from template + XML data.
+
+```text
+clippit word assemble <template.docx|-> <data.xml|-> [--output <file.docx|->] [--force] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output assembled doc path (default: `<template>-assembled.docx`). Use `-` for stdout. |
+| `--force` | Overwrite existing output file. |
+
+Only one input can use stdin at a time. Output must not overwrite template or input XML.
+
+```bash
+clippit word assemble template.docx data.xml --output assembled.docx --format json
+```
+
+```json
+{"template":"/work/template.docx","data":"/work/data.xml","output":"/work/template-assembled.docx","outputSize":42130,"templateError":false}
+```
+
+## `word accept-revisions`
+
+Accept all tracked revisions and write a cleaned `.docx`.
+
+```text
+clippit word accept-revisions <input.docx|-> [--output <file.docx|->] [--force] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output path (default: `<input>-accepted.docx`). Use `-` for stdout. |
+| `--force` | Overwrite existing output file. |
+
+```bash
+clippit word accept-revisions draft.docx --output clean.docx --format json
+```
+
+```json
+{"input":"/work/draft.docx","output":"/work/draft-accepted.docx","outputSize":42130}
+```
+
+## `word to-html`
+
+Convert `.docx` to HTML/CSS.
+
+```text
+clippit word to-html <input.docx|-> [--output <file.html|->] [--page-title <text>] [--additional-css <css>] [--css-prefix <prefix>] [--inline-images] [--no-fabricate-css] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output HTML path (default: `<input>.html`). Use `-` for stdout. |
+| `--page-title` | HTML `<title>` text. |
+| `--additional-css` | Extra CSS injected into generated `<style>`. |
+| `--css-prefix` | Prefix for generated CSS classes (default: `pt-`). |
+| `--inline-images` | Embed images as base64 data URIs. |
+| `--no-fabricate-css` | Use inline styles instead of generated CSS classes. |
+
+```bash
+clippit word to-html report.docx --inline-images --output report.html --format json
+```
+
+```json
+{"input":"/work/report.docx","output":"/work/report.html","outputSize":28473}
+```
+
+## `word from-html`
+
+Convert HTML/CSS to `.docx`.
+
+```text
+clippit word from-html <input.html|-> [--output <file.docx|->] [--css <file>] [--default-css <file>] [--user-css <css>] [--base-uri <uri>] [--major-font <name>] [--minor-font <name>] [--font-size <pt>] [--format json|text] [--quiet]
+```
+
+| Option | Description |
+| --- | --- |
+| `--output`, `-o` | Output DOCX path (default: `<input>.docx`). Use `-` for stdout. |
+| `--css`, `-c` | External author CSS file. |
+| `--default-css` | Override built-in default CSS with a file. |
+| `--user-css` | Additional CSS rules. |
+| `--base-uri` | Base URI for resolving relative image `src` paths. |
+| `--major-font` | Theme major/heading font (default: `Calibri Light`). |
+| `--minor-font` | Theme minor/body font (default: `Times New Roman`). |
+| `--font-size` | Default font size in points (default: `12`). |
+
+```bash
+clippit word from-html article.html --css styles.css --output article.docx --format json
+```
+
+```json
+{"input":"/work/article.html","output":"/work/article.docx","outputSize":45021}
+```
+

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,90 +1,65 @@
 # Clippit CLI
 
-Clippit CLI exposes PowerPoint, Word, and Excel workflows from the Clippit library as scriptable commands. It is designed for build pipelines, local deck automation, DOCX↔HTML conversion, and tools that need stable JSON output.
+Clippit CLI is a scriptable command-line interface for PowerPoint (`pptx`), Word (`word`), and Excel (`excel`) document workflows. This documentation is split into focused pages so humans and LLM agents can load only the command set they need.
 
-```bash
-clippit --help
-clippit version
-clippit pptx split deck.pptx --output slides --manifest
-clippit pptx build run slides/deck.manifest.json --output final.pptx
-clippit pptx verify final.pptx
-clippit word assemble template.docx data.xml --output assembled.docx
-clippit word compare before.docx after.docx --output compared.docx
-clippit word accept-revisions draft.docx
-clippit word verify document.docx
-clippit word to-html document.docx
-clippit word from-html article.html --css styles.css
-clippit excel to-html spreadsheet.xlsx
-clippit excel verify spreadsheet.xlsx
-```
+## CLI pages
+
+| Page | Scope |
+| --- | --- |
+| [PowerPoint CLI (`pptx`)](cli-pptx.md) | `pptx split`, `pptx build init`, `pptx build run`, `pptx verify` |
+| [Word CLI (`word`)](cli-word.md) | `word verify`, `word compare`, `word assemble`, `word accept-revisions`, `word to-html`, `word from-html` |
+| [Excel CLI (`excel`)](cli-excel.md) | `excel verify`, `excel to-html` |
 
 ## Installation
 
-You can install Clippit CLI either as a .NET global tool (NuGet) or as a Node.js global package (npm).
+You can install Clippit CLI in two supported ways.
 
-### Install from NuGet (`dotnet tool`)
+### 1. NuGet (`dotnet tool`)
 
 ```bash
 dotnet tool install -g Clippit.Cli
 clippit --version
 ```
 
-Update / uninstall:
-
 ```bash
 dotnet tool update -g Clippit.Cli
 dotnet tool uninstall -g Clippit.Cli
 ```
 
-### Install from npm
+### 2. npm
 
 ```bash
 npm install -g clippit
 clippit --version
 ```
 
-Update / uninstall:
-
 ```bash
 npm install -g clippit@latest
 npm uninstall -g clippit
 ```
 
-## Output Behavior
+## Supported platforms
 
-Every command supports `--format json|text` and `--quiet` unless it writes binary content to stdout. Text output is intended for humans; JSON output is compact and stable for automation.
+- **Continuously tested:** Windows, Linux
+- **Runtime requirement:** .NET 10 runtime/toolchain
+- **Package managers:** `dotnet tool` (NuGet) and `npm`
 
-Success payloads are written to stdout. Command execution errors are written to stderr as compact JSON with a stable symbolic `code`. Parser and help errors use System.CommandLine usage output.
+## Output contract (human + agent friendly)
 
-## Automation Contract
-
-Agents and scripts should use `--format json` when they need machine-readable command results.
+Use `--format json` for automation. Text output is for interactive usage.
 
 | Stream | Condition | Payload |
-| ------ | --------- | ------- |
-| stdout | Successful JSON command | Command-specific result JSON. |
-| stdout | `pptx verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
-| stdout | `word verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
-| stdout | `word assemble` | Result JSON (e.g. `{"template":...,"data":...,"output":...,"outputSize":...,"templateError":...}`); assembled DOCX written to `--output` path. |
-| stdout | `word compare` | Result JSON (e.g. `{"source":...,"revised":...,"output":...,"revisions":...}`); compared DOCX written to `--output` path. |
-| stdout | `excel verify` finds validation diagnostics | Verify result JSON with `valid: false`; process exits `4`. |
-| stdout | `word to-html` / `word from-html` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); converted content written to `--output` path. |
-| stdout | `word accept-revisions` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); cleaned DOCX written to `--output` path. |
-| stdout | `excel to-html` | Result JSON (e.g. `{"input":...,"output":...,"outputSize":...}`); converted HTML written to `--output` path. |
-| stdout | `pptx build run --output -` | Binary `.pptx`; no success summary is written. |
-| stdout | `word assemble --output -` | Binary `.docx` streamed to stdout; no success summary is written. |
-| stdout | `word to-html --output -` / `word from-html --output -` | Binary/HTML content streamed to stdout; no success summary is written. |
-| stdout | `word accept-revisions --output -` | Binary `.docx` streamed to stdout; no success summary is written. |
-| stdout | `excel to-html --output -` | HTML content streamed to stdout; no success summary is written. |
-| stderr | Command execution error | Compact JSON error object: `{"error":"...","code":"..."}`. |
-| stderr/stdout | Parser, arity, and help output | System.CommandLine text output, not JSON. |
-
-Do not parse text output for automation. Prefer JSON schemas and the documented properties below.
+| --- | --- | --- |
+| stdout | successful JSON command | command-specific result JSON |
+| stdout | verify command with diagnostics (`valid: false`) | verify result JSON, exit code `4` |
+| stdout | command writes binary/HTML to stdout (`--output -`) | raw stream only; summary is suppressed |
+| stderr | command execution error | compact JSON error with stable `code` |
+| stderr/stdout | parser/help output | System.CommandLine text output |
 
 Common exit codes:
 
 | Code | Meaning |
-| ---- | ------- |
+| --- | --- |
 | `0` | Success |
 | `1` | Internal error |
 | `2` | Invalid arguments |
@@ -92,465 +67,45 @@ Common exit codes:
 | `4` | Invalid format or validation failure |
 | `5` | Output error |
 
-## Stdin And Stdout
+## Stdin/stdout rules
 
-Commands that accept files use `-` for stdin where binary or JSON streaming is supported.
+- Commands that accept file input support `-` for stdin.
+- For binary/HTML output, use `--output -` and redirect stdout.
+- Only one file input can come from stdin at a time.
+
+Examples:
 
 ```bash
 cat deck.pptx | clippit pptx split - --output slides --format json
 cat deck.json | clippit pptx build run - --output - > final.pptx
-cat deck.pptx | clippit pptx verify - --format json
-cat data.xml | clippit word assemble template.docx - --output assembled.docx --format json
-cat before.docx | clippit word compare - after.docx --output compared.docx --format json
 cat document.docx | clippit word verify - --format json
-cat document.docx | clippit word accept-revisions - --output clean.docx --format json
-cat document.docx | clippit word to-html - --inline-images --output -
-cat article.html | clippit word from-html - --minor-font "Georgia" --output -
+cat article.html | clippit word from-html - --output - > article.docx
 cat spreadsheet.xlsx | clippit excel verify - --format json
 ```
 
-When `pptx build run --output -` writes a `.pptx` to stdout, the success summary is suppressed automatically so the binary stream is not corrupted.
-
-When `word assemble --output -` writes a `.docx` to stdout, the success summary is also suppressed so the binary stream is not corrupted.
-
-When `word to-html --output -` or `word from-html --output -` writes content to stdout, the success summary is also suppressed so the output stream is not corrupted.
-
-When `word accept-revisions --output -` writes a `.docx` to stdout, the success summary is also suppressed so the binary stream is not corrupted.
-
-Binary stdout output is buffered in memory before it is written to stdout. Prefer file output for very large decks.
-
 ## `version`
 
-Prints the Clippit CLI version and the Open XML SDK version used by the tool.
-
-Synopsis:
+Prints Clippit CLI and Open XML SDK versions.
 
 ```text
 clippit version [--format json|text] [--quiet]
 clippit --version
 ```
 
-```bash
-clippit version
-clippit version --format json
-clippit --version
-```
-
-JSON example:
-
 ```json
 {"version":"0.1.0","openXmlSdkVersion":"4.0.0"}
 ```
 
-## `pptx split`
+## JSON schemas
 
-Splits a `.pptx` file into individual single-slide presentations.
-
-Synopsis:
-
-```text
-clippit pptx split <input.pptx|-> [--output <dir>] [--slides <expr>] [--manifest] [--force] [--format json|text] [--quiet]
-```
-
-```bash
-clippit pptx split deck.pptx --output slides
-clippit pptx split deck.pptx --slides 1,3,6-9 --output slides
-clippit pptx split deck.pptx --output slides --manifest
-clippit pptx split deck.pptx --output slides --force
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Output directory. Defaults to the source directory, or the current directory for stdin. |
-| `--slides`, `-s` | 1-based slide numbers and inclusive ranges, for example `1,3,6-9`. Defaults to all slides. |
-| `--manifest` | Also writes a `pptx build run` compatible manifest beside the split slides. |
-| `--force` | Overwrite existing output files. |
-
-The generated manifest preserves source presentation sections when present.
-
-JSON example:
-
-```json
-{"input":"/work/deck.pptx","outputDir":"/work/slides","manifest":"/work/slides/deck.manifest.json","count":2,"slides":[{"index":1,"file":"/work/slides/deck-001.pptx","title":"Intro"},{"index":3,"file":"/work/slides/deck-003.pptx","title":null}]}
-```
-
-## `pptx build init`
-
-Scaffolds an empty deck manifest.
-
-Synopsis:
-
-```text
-clippit pptx build init [--output <manifest.json|->] [--force] [--format json|text] [--quiet]
-```
-
-```bash
-clippit pptx build init
-clippit pptx build init --output deck.json --force
-clippit pptx build init --output - > deck.json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Manifest path. Defaults to `./clippit-deck.json`. Use `-` to write JSON to stdout. |
-| `--force` | Overwrite an existing manifest file. |
-
-Deck manifests include a `$schema` URL so editors and CI jobs can validate authored input files against `docs/schemas/deck-manifest.v1.json`.
-
-Minimal manifest example:
-
-```json
-{
-  "$schema": "https://sergey-tihon.github.io/Clippit/schemas/deck-manifest.v1.json",
-  "title": "Conference Deck",
-  "output": "final.pptx",
-  "deck": [
-    { "section": "Opening" },
-    "intro.pptx",
-    { "file": "demo.pptx", "keepSections": true },
-    { "section": "Appendix" },
-    { "file": "appendix.pptx", "masters": true, "slides": true }
-  ]
-}
-```
-
-Manifest rules for agents:
-
-| Property | Required | Notes |
-| -------- | -------- | ----- |
-| `title` | Yes | Written to output presentation core properties. |
-| `output` | Yes | Relative paths resolve against the manifest file directory. |
-| `deck` | Yes | Ordered entries; must contain at least one entry. |
-| string entry | No | `[Section Name]` creates a section divider; any other string is a source `.pptx` path. |
-| `{ "section": "Name" }` | No | Explicit section divider. |
-| `{ "file": "deck.pptx" }` | No | Source `.pptx` entry. Optional booleans: `masters`, `slides`, `keepSections`. |
-
-## `pptx build run`
-
-Builds a final `.pptx` from a deck manifest.
-
-Synopsis:
-
-```text
-clippit pptx build run <manifest.json|-> [--output <file.pptx|->] [--force] [--format json|text] [--quiet]
-```
-
-```bash
-clippit pptx build run deck.json
-clippit pptx build run deck.json --output final.pptx --force
-clippit pptx build run deck.json --format json
-cat deck.json | clippit pptx build run - --output - > final.pptx
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Override the manifest output path. Use `-` to write the binary `.pptx` to stdout. |
-| `--force` | Overwrite the output presentation if it already exists. |
-
-Without `--force`, the command fails before replacing an existing output file.
-
-JSON example:
-
-```json
-{"output":"/work/final.pptx","totalSlides":12,"entries":[{"section":"Opening"},{"file":"intro.pptx","slides":3},{"file":"demo.pptx","slides":9}]}
-```
-
-## `pptx verify`
-
-Validates that a `.pptx` file is a readable and structurally correct Open XML presentation. The command checks package readability, Open XML schema errors, dangling relationships, markup compatibility issues, and Clippit presentation-section metadata.
-
-Synopsis:
-
-```text
-clippit pptx verify <input.pptx|-> [--office-version <version>] [--format json|text] [--quiet]
-```
-
-```bash
-clippit pptx verify deck.pptx
-clippit pptx verify deck.pptx --format json
-clippit pptx verify deck.pptx --office-version Office2021
-cat deck.pptx | clippit pptx verify - --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--office-version` | Open XML schema version to validate against. Defaults to `Microsoft365`. |
-
-Invalid-but-readable presentations produce a validation result on stdout and exit with code `4`. JSON results include `diagnostics`; each diagnostic has a `kind`, message, and optional validator code/location fields.
-
-Current diagnostic kinds are documented in [schemas/README.md](schemas/README.md).
-
-Valid JSON example:
-
-```json
-{"input":"/work/deck.pptx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
-```
-
-Invalid JSON example:
-
-```json
-{"input":"/work/deck.pptx","officeVersion":"Microsoft365","valid":false,"diagnostics":[{"kind":"relationship","code":null,"description":"Dangling relationship target.","part":"/ppt/slides/slide1.xml","path":null,"element":null,"attribute":"id","relationshipId":"rId9"}]}
-```
-
-## `word verify`
-
-Validates that a `.docx` file is a readable and structurally correct Open XML document. The command checks package readability, Open XML schema errors, dangling relationships, and markup compatibility issues.
-
-Synopsis:
-
-```text
-clippit word verify <input.docx|-> [--office-version <version>] [--format json|text] [--quiet]
-```
-
-```bash
-clippit word verify document.docx
-clippit word verify document.docx --format json
-clippit word verify document.docx --office-version Office2021
-cat document.docx | clippit word verify - --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--office-version` | Open XML schema version to validate against. Defaults to `Microsoft365`. |
-
-Invalid-but-readable documents produce a validation result on stdout and exit with code `4`. JSON results include `diagnostics`; each diagnostic has a `kind`, message, and optional validator code/location fields. The payload shape matches `pptx verify` and is documented in [schemas/README.md](schemas/README.md).
-
-Valid JSON example:
-
-```json
-{"input":"/work/document.docx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
-```
-
-## `word compare`
-
-Compares two `.docx` files and writes a result document with tracked revisions.
-The command wraps `WmlComparer.Compare`.
-
-Synopsis:
-
-```text
-clippit word compare <source.docx|-> <revised.docx|-> [--output <file.docx|->] [--author <text>] [--date-time <text>] [--case-insensitive] [--format json|text] [--quiet]
-```
-
-```bash
-clippit word compare before.docx after.docx
-clippit word compare before.docx after.docx --output compared.docx --format json
-clippit word compare before.docx after.docx --author "Jane Doe" --date-time 2026-01-01T00:00:00Z
-cat before.docx | clippit word compare - after.docx --output compared.docx --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Output path for the compared `.docx` file. Defaults to `<source>-compared.docx`. Use `-` to write binary content to stdout. |
-| `--author` | Author value used for generated tracked revisions. |
-| `--date-time` | Date/time value used for generated tracked revisions. |
-| `--case-insensitive` | Ignore case when comparing words. |
-
-The `authorForRevisions` and `dateTimeForRevisions` fields echo back the effective
-values. When `--author`/`--date-time` are omitted they default to `Open-Xml-PowerTools`
-and the current local time (round-trip `o` format). When provided, the exact strings are
-echoed back without reformatting.
-
-JSON example (for `--author "Jane Doe" --date-time 2026-01-01T00:00:00Z --output compared.docx --format json`):
-
-```json
-{"source":"/work/before.docx","revised":"/work/after.docx","output":"/work/compared.docx","outputSize":59321,"revisions":8,"authorForRevisions":"Jane Doe","dateTimeForRevisions":"2026-01-01T00:00:00Z","caseInsensitive":false}
-```
-
-## `word assemble`
-
-Assembles a `.docx` document from a template and XML data.
-The command wraps `DocumentAssembler.AssembleDocument`.
-
-Synopsis:
-
-```text
-clippit word assemble <template.docx|-> <data.xml|-> [--output <file.docx|->] [--force] [--format json|text] [--quiet]
-```
-
-```bash
-clippit word assemble template.docx data.xml
-clippit word assemble template.docx data.xml --output assembled.docx --format json
-clippit word assemble template.docx - --output assembled.docx
-cat data.xml | clippit word assemble template.docx - --output assembled.docx --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Output path for the assembled `.docx` file. Defaults to `<template>-assembled.docx`. Use `-` to write binary content to stdout. |
-| `--force` | Overwrite the output file if it already exists. |
-
-Only one input can be read from stdin at a time. The output path must not overwrite the template or XML data input file, even when `--force` is used.
-
-JSON example:
-
-```json
-{"template":"/work/template.docx","data":"/work/data.xml","output":"/work/template-assembled.docx","outputSize":42130,"templateError":false}
-```
-
-## `word accept-revisions`
-
-Accepts all tracked revisions in a `.docx` file and writes the cleaned document.
-The command wraps `RevisionAccepter.AcceptRevisions`.
-
-Synopsis:
-
-```text
-clippit word accept-revisions <input.docx|-> [--output <file.docx|->] [--force] [--format json|text] [--quiet]
-```
-
-```bash
-clippit word accept-revisions draft.docx
-clippit word accept-revisions draft.docx --output clean.docx --format json
-clippit word accept-revisions draft.docx --output - > clean.docx
-cat draft.docx | clippit word accept-revisions - --output clean.docx --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Output path for the cleaned `.docx` file. Defaults to `<input>-accepted.docx`. Use `-` to write binary content to stdout. |
-| `--force` | Overwrite the output file if it already exists. |
-
-JSON example:
-
-```json
-{"input":"/work/draft.docx","output":"/work/draft-accepted.docx","outputSize":42130}
-```
-
-## `excel verify`
-
-Validates that a `.xlsx` file is a readable and structurally correct Open XML spreadsheet. The command checks package readability, Open XML schema errors, dangling relationships, and markup compatibility issues.
-
-Synopsis:
-
-```text
-clippit excel verify <input.xlsx|-> [--office-version <version>] [--format json|text] [--quiet]
-```
-
-```bash
-clippit excel verify spreadsheet.xlsx
-clippit excel verify spreadsheet.xlsx --format json
-clippit excel verify spreadsheet.xlsx --office-version Office2021
-cat spreadsheet.xlsx | clippit excel verify - --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--office-version` | Open XML schema version to validate against. Defaults to `Microsoft365`. |
-
-Invalid-but-readable spreadsheets produce a validation result on stdout and exit with code `4`. JSON results include `diagnostics`; each diagnostic has a `kind`, message, and optional validator code/location fields. The payload shape matches `pptx verify` and is documented in [schemas/README.md](schemas/README.md).
-
-Valid JSON example:
-
-```json
-{"input":"/work/spreadsheet.xlsx","officeVersion":"Microsoft365","valid":true,"diagnostics":[]}
-```
-
-## `word to-html`
-
-Converts a `.docx` file to HTML/CSS with high-fidelity layout preservation.
-Images can be embedded as base64 data URIs (`--inline-images`) or referenced as
-separate files. The command wraps `WmlToHtmlConverter` from the Clippit library.
-
-Synopsis:
-
-```text
-clippit word to-html <input.docx|-> [--output <file.html|->] [--page-title <text>] [--additional-css <css>] [--css-prefix <prefix>] [--inline-images] [--no-fabricate-css] [--format json|text] [--quiet]
-```
-
-```bash
-clippit word to-html report.docx
-clippit word to-html report.docx --page-title "Q3 Report" --additional-css "body { max-width: 800px; }"
-clippit word to-html report.docx --inline-images --output - > report.html
-cat document.docx | clippit word to-html - --inline-images --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Output path for the generated `.html` file. Defaults to `<input>.html`. Use `-` to write HTML content to stdout. |
-| `--page-title` | HTML page `<title>`. Defaults to the source file name. |
-| `--additional-css` | Extra CSS rules injected into the generated `<style>` block. |
-| `--css-prefix` | Prefix for auto-generated CSS class names (default: `pt-`). |
-| `--inline-images` | Embed images as base64 data URIs instead of linking to external files. |
-| `--no-fabricate-css` | Skip CSS class generation and use inline `style` attributes instead. |
-
-JSON example:
-
-```json
-{"input":"/work/report.docx","output":"/work/report.html","outputSize":28473}
-```
-
-## `word from-html`
-
-Converts an HTML document to a `.docx` file, restoring styles, images, and layout
-as Open XML markup. CSS in the HTML `<style>` element is extracted automatically;
-external CSS can also be passed with `--css`. The command wraps
-`HtmlToWmlConverter` from the Clippit library.
-
-Synopsis:
-
-```text
-clippit word from-html <input.html|-> [--output <file.docx|->] [--css <file>] [--default-css <file>] [--user-css <css>] [--base-uri <uri>] [--major-font <name>] [--minor-font <name>] [--font-size <pt>] [--format json|text] [--quiet]
-```
-
-```bash
-clippit word from-html article.html
-clippit word from-html article.html -c styles.css -o article.docx
-clippit word from-html article.html --minor-font "Georgia" --font-size 11
-cat article.html | clippit word from-html - --base-uri https://example.com/images/ --format json
-```
-
-Options:
-
-| Option | Description |
-| ------ | ----------- |
-| `--output`, `-o` | Output path for the generated `.docx` file. Defaults to `<input>.docx`. Use `-` to write binary content to stdout. |
-| `--css`, `-c` | Path to an external author CSS file. When omitted, CSS is extracted from the HTML `<style>` element. |
-| `--default-css` | Path to a default CSS file to override the built-in default CSS. |
-| `--user-css` | Additional CSS rules to apply as user overrides. |
-| `--base-uri` | Base URI for resolving relative image `src` references. Defaults to the source HTML file's parent directory. |
-| `--major-font` | Theme major (heading) font name (default: `Calibri Light`). |
-| `--minor-font` | Theme minor (body) font name (default: `Times New Roman`). |
-| `--font-size` | Default font size in points (default: `12`). |
-
-JSON example:
-
-```json
-{"input":"/work/article.html","output":"/work/article.docx","outputSize":45021}
-```
-
-## JSON Schemas
-
-Schemas for deck manifests and CLI result payloads are published in [docs/schemas](schemas/README.md). Result schemas are intended for documentation, integration tests, and downstream contract validation; result payloads do not embed schema URLs.
-
-Canonical schema URLs:
+Schemas for manifests/results are in [schemas/README.md](schemas/README.md).
 
 | Payload | URL |
-| ------- | --- |
+| --- | --- |
 | Deck manifest | `https://sergey-tihon.github.io/Clippit/schemas/deck-manifest.v1.json` |
 | `pptx split` result | `https://sergey-tihon.github.io/Clippit/schemas/split-result.v1.json` |
 | `pptx build run` result | `https://sergey-tihon.github.io/Clippit/schemas/build-result.v1.json` |
 | `pptx verify`, `word verify`, `excel verify` result | `https://sergey-tihon.github.io/Clippit/schemas/verify-result.v1.json` |
 | `word assemble` result | `https://sergey-tihon.github.io/Clippit/schemas/assemble-result.v1.json` |
 | `word compare` result | `https://sergey-tihon.github.io/Clippit/schemas/compare-result.v1.json` |
-| `word to-html`, `word from-html`, `word accept-revisions` result | `https://sergey-tihon.github.io/Clippit/schemas/convert-result.v1.json` |
+| `word to-html`, `word from-html`, `word accept-revisions`, `excel to-html` result | `https://sergey-tihon.github.io/Clippit/schemas/convert-result.v1.json` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -270,7 +270,7 @@
 
 # Clippit — Fresh PowerTools for OpenXml
 
-Clippit is a .NET library for programmatically creating, modifying, and converting Word (DOCX), Excel (XLSX), and PowerPoint (PPTX) documents. Built on top of the [Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK), it provides high-level APIs that handle the complexity of the Open XML format so you can focus on your content. It also includes a [scriptable CLI](cli.md) for PowerPoint split/build workflows, Word template assembly, and document validation/conversion tasks.
+Clippit is a .NET library for programmatically creating, modifying, and converting Word (DOCX), Excel (XLSX), and PowerPoint (PPTX) documents. Built on top of the [Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK), it provides high-level APIs that handle the complexity of the Open XML format so you can focus on your content. It also includes a [scriptable CLI](cli.md) with a compact start page and dedicated [PowerPoint](cli-pptx.md), [Word](cli-word.md), and [Excel](cli-excel.md) command references.
 
 ## Getting Started
 
@@ -338,7 +338,7 @@ signatures and code samples.
 
 | Feature | Description |
 | ------- | ----------- |
-| [Clippit CLI](cli.md) | Scriptable PPTX split/build/verify, DOCX validation, and DOCX↔HTML conversion with human-readable text output, stable JSON output, stdin/stdout support, and JSON schemas for automation |
+| [Clippit CLI](cli.md) | Scriptable PPTX split/build/verify, DOCX validation and conversion, and XLSX validation/conversion with a concise start page plus dedicated [PowerPoint](cli-pptx.md), [Word](cli-word.md), and [Excel](cli-excel.md) references |
 
 ### Common
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2,6 +2,13 @@
   href: index.md
 - name: CLI
   href: cli.md
+  items:
+    - name: PowerPoint CLI (pptx)
+      href: cli-pptx.md
+    - name: Word CLI (word)
+      href: cli-word.md
+    - name: Excel CLI (excel)
+      href: cli-excel.md
 - name: Tutorials
   href: tutorials/
 - name: API Documentation


### PR DESCRIPTION
## Why
The CLI documentation had grown into a single long page that was harder to scan for humans and expensive to load for LLM agents. Splitting by command domain makes the docs easier to navigate and more token-efficient when linking agents to one focused reference.

## What changed
- Reworked `docs/cli.md` into a concise CLI start page with:
  - installation paths (`dotnet tool` and `npm`)
  - supported platforms/runtime notes
  - shared output/automation contract and exit codes
  - stdin/stdout rules
  - links to domain-specific command pages
- Added dedicated command reference pages:
  - `docs/cli-pptx.md`
  - `docs/cli-word.md`
  - `docs/cli-excel.md`
- Updated docs navigation in `docs/toc.yml` to include nested CLI pages.
- Updated `docs/index.md` CLI descriptions/links to point to the split docs structure.

## Notes for reviewers
- The split keeps command examples and JSON payload samples on each domain page while moving common guidance to the start page.
- This change is documentation-only; no CLI behavior or command contracts were changed.