### PR TITLE
[Clippy] feat: add `clippit word consolidate` command

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.8.0] - 2026-07-07
+
+- Added `word consolidate` command to combine multiple revisions of a document into one
+  file with tracked changes. Wraps `WmlComparer.Consolidate`. Supports one positional
+  original argument and one or more revision arguments. Reviewer names and hex colors
+  can be assigned with `--revisor` and `--color` (repeated per revision; defaults to the
+  revision file name and a rotating palette). Additional options: `--author`,
+  `--date-time`, `--case-insensitive`, `--no-table-consolidation`, `--output`/`-o`
+  (defaults to `<original>-consolidated.docx`, `-` for stdout), `--force`,
+  `--format json`, `--quiet`. Supports stdin (`-`) for the original. Mismatched
+  `--revisor`/`--color` counts or zero revision files return `INVALID_ARGUMENTS`
+  (exit 2). Published schema: `consolidate-result.v1.json` (#379).
+
 ## [0.7.0] - 2026-07-05
 
 - Added `word simplify-markup` command to remove non-content markup from a `.docx` file.

--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.8.0] - 2026-07-07
+## [0.7.0] - 2026-07-05
 
 - Added `word consolidate` command to combine multiple revisions of a document into one
   file with tracked changes. Wraps `WmlComparer.Consolidate`. Supports one positional
@@ -14,9 +14,6 @@
   revision files return `INVALID_ARGUMENTS` (exit 2). When `--output -` is used, stdout
   is reserved for the binary DOCX stream and the JSON result is suppressed. Published
   schema: `consolidate-result.v1.json` (#379).
-
-## [0.7.0] - 2026-07-05
-
 - Added `word simplify-markup` command to remove non-content markup from a `.docx` file.
   Wraps `MarkupSimplifier.SimplifyMarkup`. Accepts one flag per `SimplifyMarkupSettings`
   boolean field (`--accept-revisions`, `--remove-rsid-info`, `--remove-markup-for-document-comparison`,

--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -9,9 +9,11 @@
   revision file name and a rotating palette). Additional options: `--author`,
   `--date-time`, `--case-insensitive`, `--no-table-consolidation`, `--output`/`-o`
   (defaults to `<original>-consolidated.docx`, `-` for stdout), `--force`,
-  `--format json`, `--quiet`. Supports stdin (`-`) for the original. Mismatched
-  `--revisor`/`--color` counts or zero revision files return `INVALID_ARGUMENTS`
-  (exit 2). Published schema: `consolidate-result.v1.json` (#379).
+  `--format json`, `--quiet`. Supports stdin (`-`) for the original document; revision
+  files must be filesystem paths. Mismatched `--revisor`/`--color` counts or zero
+  revision files return `INVALID_ARGUMENTS` (exit 2). When `--output -` is used, stdout
+  is reserved for the binary DOCX stream and the JSON result is suppressed. Published
+  schema: `consolidate-result.v1.json` (#379).
 
 ## [0.7.0] - 2026-07-05
 

--- a/Clippit.Cli/CliJsonContext.cs
+++ b/Clippit.Cli/CliJsonContext.cs
@@ -6,6 +6,7 @@ using Clippit.Cli.Commands.Pptx.Verify;
 using Clippit.Cli.Commands.Version;
 using Clippit.Cli.Commands.Word.Assemble;
 using Clippit.Cli.Commands.Word.Compare;
+using Clippit.Cli.Commands.Word.Consolidate;
 using Clippit.Cli.Infrastructure;
 
 namespace Clippit.Cli;
@@ -31,6 +32,8 @@ namespace Clippit.Cli;
 [JsonSerializable(typeof(ConvertResult))]
 [JsonSerializable(typeof(CompareResult))]
 [JsonSerializable(typeof(AssembleResult))]
+[JsonSerializable(typeof(ConsolidateResult))]
+[JsonSerializable(typeof(IReadOnlyList<RevisionInfoResult>))]
 [JsonSerializable(typeof(ErrorResult))]
 [JsonSourceGenerationOptions(
     WriteIndented = false,

--- a/Clippit.Cli/Commands/Word/Consolidate/ConsolidateResult.cs
+++ b/Clippit.Cli/Commands/Word/Consolidate/ConsolidateResult.cs
@@ -1,0 +1,26 @@
+namespace Clippit.Cli.Commands.Word.Consolidate;
+
+internal sealed record RevisionInfoResult
+{
+    public required string File { get; init; }
+    public required string Revisor { get; init; }
+    public required string Color { get; init; }
+}
+
+internal sealed record ConsolidateResult
+{
+    public required string Original { get; init; }
+    public required IReadOnlyList<RevisionInfoResult> Revisions { get; init; }
+    public required string Output { get; init; }
+    public required long OutputSize { get; init; }
+
+    public static void WriteText(ConsolidateResult result, TextWriter writer)
+    {
+        writer.WriteLine($"Original: {result.Original}");
+        writer.WriteLine($"Revisions: {result.Revisions.Count}");
+        foreach (var rev in result.Revisions)
+            writer.WriteLine($"  {rev.File} ({rev.Revisor}, {rev.Color})");
+        writer.WriteLine($"Output: {result.Output}");
+        writer.WriteLine($"Output size: {result.OutputSize} bytes");
+    }
+}

--- a/Clippit.Cli/Commands/Word/Consolidate/WordConsolidateCommand.cs
+++ b/Clippit.Cli/Commands/Word/Consolidate/WordConsolidateCommand.cs
@@ -1,0 +1,164 @@
+using System.CommandLine;
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Word.Consolidate;
+
+internal static class WordConsolidateCommand
+{
+    public static Command Build()
+    {
+        var originalArg = InputSource.BuildArgument(
+            "original",
+            "Path to the original .docx file. Use '-' to read from stdin."
+        );
+        var revisionsArg = new Argument<string[]>("revisions") { Description = "One or more revision .docx files." };
+        revisionsArg.Validators.Add(result =>
+        {
+            var values = result.GetValueOrDefault<string[]>() ?? [];
+            foreach (var value in values)
+            {
+                if (value != InputSource.StdinToken && !File.Exists(value))
+                    result.AddError($"Revision file not found: {value}");
+            }
+        });
+
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description =
+                "Output path for the consolidated .docx file. "
+                + "Defaults to <original>-consolidated.docx. Use '-' to write binary content to stdout.",
+        };
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Overwrite the output file if it already exists.",
+        };
+
+        var revisorOption = new Option<string[]?>("--revisor")
+        {
+            Description =
+                "Reviewer name for the corresponding revision file. May be repeated; defaults to the revision file name.",
+            AllowMultipleArgumentsPerToken = false,
+        };
+        revisorOption.Arity = ArgumentArity.ZeroOrMore;
+
+        var colorOption = new Option<string[]?>("--color")
+        {
+            Description =
+                "Hex color (#RRGGBB) for the corresponding revision. May be repeated; defaults to a rotating palette.",
+            AllowMultipleArgumentsPerToken = false,
+        };
+        colorOption.Arity = ArgumentArity.ZeroOrMore;
+
+        var authorOption = new Option<string?>("--author")
+        {
+            Description = "Author value used for generated tracked revisions.",
+        };
+
+        var dateTimeOption = new Option<string?>("--date-time")
+        {
+            Description = "Date/time value used for generated tracked revisions (ISO 8601 text recommended).",
+        };
+
+        var caseInsensitiveOption = new Option<bool>("--case-insensitive")
+        {
+            Description = "Ignore case when comparing words.",
+        };
+
+        var noTableConsolidationOption = new Option<bool>("--no-table-consolidation")
+        {
+            Description = "Disable table-based consolidation layout.",
+        };
+
+        var cmd = new Command(
+            "consolidate",
+            "Combine multiple revisions of a document into one file with tracked changes."
+                + "\n\nExamples:"
+                + "\n  clippit word consolidate original.docx alice.docx bob.docx"
+                + "\n  clippit word consolidate original.docx alice.docx bob.docx --output consolidated.docx --format json"
+                + "\n  clippit word consolidate original.docx alice.docx bob.docx --revisor Alice --revisor Bob --color '#FF0000' --color '#0000FF'"
+                + "\n  cat original.docx | clippit word consolidate - alice.docx bob.docx --output consolidated.docx"
+        );
+        cmd.Arguments.Add(originalArg);
+        cmd.Arguments.Add(revisionsArg);
+        cmd.Options.Add(outputOption);
+        cmd.Options.Add(forceOption);
+        cmd.Options.Add(revisorOption);
+        cmd.Options.Add(colorOption);
+        cmd.Options.Add(authorOption);
+        cmd.Options.Add(dateTimeOption);
+        cmd.Options.Add(caseInsensitiveOption);
+        cmd.Options.Add(noTableConsolidationOption);
+        var (formatOption, quietOption) = cmd.AddOutputOptions();
+
+        cmd.SetAction(parseResult =>
+            CommandRunner.Execute(() =>
+                Run(
+                    parseResult.GetValue(originalArg)!,
+                    parseResult.GetValue(revisionsArg) ?? [],
+                    parseResult.GetValue(revisorOption) ?? [],
+                    parseResult.GetValue(colorOption) ?? [],
+                    parseResult.GetValue(outputOption),
+                    parseResult.GetValue(forceOption),
+                    parseResult.GetValue(authorOption),
+                    parseResult.GetValue(dateTimeOption),
+                    parseResult.GetValue(caseInsensitiveOption),
+                    parseResult.GetValue(noTableConsolidationOption),
+                    parseResult.GetValue(formatOption),
+                    parseResult.GetValue(quietOption)
+                )
+            )
+        );
+
+        return cmd;
+    }
+
+    private static int Run(
+        string originalPath,
+        string[] revisionPaths,
+        string[] revisors,
+        string[] colors,
+        string? outputPath,
+        bool force,
+        string? authorForRevisions,
+        string? dateTimeForRevisions,
+        bool caseInsensitive,
+        bool noTableConsolidation,
+        OutputFormat format,
+        bool quiet
+    )
+    {
+        if (revisionPaths.Length == 0)
+            throw CliException.InvalidArguments("At least one revision document must be supplied.");
+
+        var original = InputSource.From(originalPath, "stdin-original.docx");
+
+        var revisions = revisionPaths
+            .Select((path, i) => InputSource.From(path, $"stdin-revision-{i + 1}.docx"))
+            .ToList();
+
+        var defaultOutput = original.IsStdin
+            ? "consolidated.docx"
+            : Path.Combine(
+                Path.GetDirectoryName(original.DisplayName)!,
+                $"{Path.GetFileNameWithoutExtension(original.DisplayName)}-consolidated.docx"
+            );
+        var output = OutputTarget.FromOption(outputPath, () => defaultOutput);
+        var writer = new OutputWriter(format, quiet || output.IsStdout);
+
+        var result = WordConsolidateService.Execute(
+            original,
+            revisions,
+            revisors,
+            colors,
+            output,
+            force,
+            authorForRevisions,
+            dateTimeForRevisions,
+            caseInsensitive,
+            noTableConsolidation
+        );
+        writer.WriteResult(result, CliJsonContext.Default.ConsolidateResult, ConsolidateResult.WriteText);
+        return ExitCodes.Success;
+    }
+}

--- a/Clippit.Cli/Commands/Word/Consolidate/WordConsolidateCommand.cs
+++ b/Clippit.Cli/Commands/Word/Consolidate/WordConsolidateCommand.cs
@@ -17,7 +17,11 @@ internal static class WordConsolidateCommand
             var values = result.GetValueOrDefault<string[]>() ?? [];
             foreach (var value in values)
             {
-                if (value != InputSource.StdinToken && !File.Exists(value))
+                if (value == InputSource.StdinToken)
+                    result.AddError(
+                        "Revision files must be filesystem paths; stdin ('-') is not permitted for revisions."
+                    );
+                else if (!File.Exists(value))
                     result.AddError($"Revision file not found: {value}");
             }
         });

--- a/Clippit.Cli/Commands/Word/Consolidate/WordConsolidateService.cs
+++ b/Clippit.Cli/Commands/Word/Consolidate/WordConsolidateService.cs
@@ -1,0 +1,192 @@
+using System.Drawing;
+using Clippit.Cli.Infrastructure;
+using Clippit.Word;
+
+namespace Clippit.Cli.Commands.Word.Consolidate;
+
+internal static class WordConsolidateService
+{
+    private static readonly Color[] s_defaultPalette =
+    [
+        Color.FromArgb(0xFF, 0x00, 0x00), // red
+        Color.FromArgb(0x00, 0x00, 0xFF), // blue
+        Color.FromArgb(0x00, 0x80, 0x00), // green
+        Color.FromArgb(0xFF, 0xA5, 0x00), // orange
+        Color.FromArgb(0x80, 0x00, 0x80), // purple
+    ];
+
+    public static ConsolidateResult Execute(
+        InputSource original,
+        IReadOnlyList<InputSource> revisions,
+        IReadOnlyList<string?> revisors,
+        IReadOnlyList<string?> colors,
+        OutputTarget output,
+        bool force,
+        string? authorForRevisions,
+        string? dateTimeForRevisions,
+        bool caseInsensitive,
+        bool noTableConsolidation
+    )
+    {
+        if (revisions.Count == 0)
+            throw CliException.InvalidArguments("At least one revision document must be supplied.");
+
+        if (revisors.Count > 0 && revisors.Count != revisions.Count)
+            throw CliException.InvalidArguments(
+                $"Number of --revisor values ({revisors.Count}) must match the number of revision files ({revisions.Count})."
+            );
+
+        if (colors.Count > 0 && colors.Count != revisions.Count)
+            throw CliException.InvalidArguments(
+                $"Number of --color values ({colors.Count}) must match the number of revision files ({revisions.Count})."
+            );
+
+        if (!output.IsStdout)
+        {
+            if (!original.IsStdin && PathsEqual(output.DisplayPath, original.DisplayName))
+                throw CliException.OutputError("Output path must not overwrite the original document.");
+
+            foreach (var rev in revisions)
+            {
+                if (!rev.IsStdin && PathsEqual(output.DisplayPath, rev.DisplayName))
+                    throw CliException.OutputError("Output path must not overwrite a revision document.");
+            }
+        }
+
+        var settings = new WmlComparerSettings { CaseInsensitive = caseInsensitive };
+        if (!string.IsNullOrWhiteSpace(authorForRevisions))
+            settings.AuthorForRevisions = authorForRevisions;
+        if (!string.IsNullOrWhiteSpace(dateTimeForRevisions))
+            settings.DateTimeForRevisions = dateTimeForRevisions;
+
+        var consolidateSettings = new WmlComparerConsolidateSettings { ConsolidateWithTable = !noTableConsolidation };
+
+        byte[] originalBytes;
+        using (var stream = original.OpenSeekable())
+        using (var memory = new MemoryStream())
+        {
+            stream.CopyTo(memory);
+            originalBytes = memory.ToArray();
+        }
+
+        var originalDoc = new WmlDocument(original.LogicalName, originalBytes);
+
+        var revisionInfos = new List<WmlRevisedDocumentInfo>(revisions.Count);
+        var resultRevisions = new List<RevisionInfoResult>(revisions.Count);
+
+        for (var i = 0; i < revisions.Count; i++)
+        {
+            var rev = revisions[i];
+            byte[] revBytes;
+            using (var stream = rev.OpenSeekable())
+            using (var memory = new MemoryStream())
+            {
+                stream.CopyTo(memory);
+                revBytes = memory.ToArray();
+            }
+
+            var revisor = revisors.Count > 0 ? revisors[i] : null;
+            revisor ??= rev.IsStdin ? "Revisor" : Path.GetFileNameWithoutExtension(rev.DisplayName);
+
+            var colorStr = colors.Count > 0 ? colors[i] : null;
+            var color = ParseColor(colorStr, i);
+            var colorHex = $"#{color.R:X2}{color.G:X2}{color.B:X2}";
+
+            revisionInfos.Add(
+                new WmlRevisedDocumentInfo
+                {
+                    RevisedDocument = new WmlDocument(rev.LogicalName, revBytes),
+                    Revisor = revisor,
+                    Color = color,
+                }
+            );
+
+            resultRevisions.Add(
+                new RevisionInfoResult
+                {
+                    File = rev.DisplayName,
+                    Revisor = revisor,
+                    Color = colorHex,
+                }
+            );
+        }
+
+        WmlDocument consolidated;
+        try
+        {
+            consolidated = WmlComparer.Consolidate(originalDoc, revisionInfos, settings, consolidateSettings);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.InvalidFormat($"Could not consolidate document: {ex.Message}");
+        }
+
+        string? tempPath = null;
+        Stream outputStream;
+        try
+        {
+            output.EnsureCanWrite(force, "output");
+            output.EnsureDirectoryExists();
+            outputStream = output.OpenWrite(out tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not open output for writing: {ex.Message}");
+        }
+
+        try
+        {
+            try
+            {
+                outputStream.Write(consolidated.DocumentByteArray, 0, consolidated.DocumentByteArray.Length);
+                outputStream.Flush();
+
+                if (output.IsStdout)
+                    output.Flush(outputStream);
+            }
+            finally
+            {
+                outputStream.Dispose();
+            }
+
+            if (!output.IsStdout)
+                output.Commit(tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not write output: {ex.Message}");
+        }
+        finally
+        {
+            OutputTarget.DeleteTemp(tempPath);
+        }
+
+        return new ConsolidateResult
+        {
+            Original = original.DisplayName,
+            Revisions = resultRevisions,
+            Output = output.DisplayPath,
+            OutputSize = consolidated.DocumentByteArray.Length,
+        };
+    }
+
+    private static Color ParseColor(string? colorStr, int index)
+    {
+        if (string.IsNullOrWhiteSpace(colorStr))
+            return s_defaultPalette[index % s_defaultPalette.Length];
+
+        var s = colorStr.TrimStart('#');
+        if (s.Length == 6 && uint.TryParse(s, System.Globalization.NumberStyles.HexNumber, null, out var rgb))
+            return Color.FromArgb((int)((rgb >> 16) & 0xFF), (int)((rgb >> 8) & 0xFF), (int)(rgb & 0xFF));
+
+        throw CliException.InvalidArguments($"Invalid color value '{colorStr}'. Expected a hex color like #FF0000.");
+    }
+
+    private static bool PathsEqual(string left, string right) =>
+        string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), PathComparison);
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+}

--- a/Clippit.Cli/Commands/Word/WordCommand.cs
+++ b/Clippit.Cli/Commands/Word/WordCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using Clippit.Cli.Commands.Word.AcceptRevisions;
 using Clippit.Cli.Commands.Word.Assemble;
 using Clippit.Cli.Commands.Word.Compare;
+using Clippit.Cli.Commands.Word.Consolidate;
 using Clippit.Cli.Commands.Word.FromHtml;
 using Clippit.Cli.Commands.Word.SimplifyMarkup;
 using Clippit.Cli.Commands.Word.ToHtml;
@@ -20,6 +21,7 @@ internal static class WordCommand
         cmd.Subcommands.Add(WordAcceptRevisionsCommand.Build());
         cmd.Subcommands.Add(WordAssembleCommand.Build());
         cmd.Subcommands.Add(WordCompareCommand.Build());
+        cmd.Subcommands.Add(WordConsolidateCommand.Build());
         cmd.Subcommands.Add(WordSimplifyMarkupCommand.Build());
         cmd.Subcommands.Add(WordVerifyCommand.Build());
         cmd.Subcommands.Add(WordToHtmlCommand.Build());

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -26,11 +26,17 @@ clippit word verify document.docx
 # Compare two DOCX files with tracked revisions
 clippit word compare before.docx after.docx --output compared.docx
 
+# Consolidate multiple DOCX revisions into one tracked-changes file
+clippit word consolidate original.docx alice.docx bob.docx --output consolidated.docx
+
 # Assemble a DOCX template with XML data
 clippit word assemble template.docx data.xml --output assembled.docx
 
 # Accept all tracked revisions in a DOCX file
 clippit word accept-revisions draft.docx
+
+# Remove non-content markup from a DOCX file
+clippit word simplify-markup document.docx --accept-revisions --remove-comments
 
 # Convert DOCX to HTML
 clippit word to-html document.docx
@@ -55,7 +61,9 @@ clippit pptx split presentation.pptx --format json
 | `pptx verify` | Validate a PPTX — schema, relationships, markup compatibility, and sections. |
 | `word assemble` | Assemble a DOCX template with XML data. |
 | `word compare` | Compare two DOCX files and produce a tracked-revision DOCX. |
+| `word consolidate` | Combine multiple DOCX revisions into one tracked-changes DOCX. |
 | `word accept-revisions` | Accept all tracked revisions in a DOCX file. |
+| `word simplify-markup` | Remove non-content markup from a DOCX file. |
 | `word verify` | Validate a DOCX — schema and relationships. |
 | `word to-html` | Convert a DOCX to HTML/CSS. |
 | `word from-html` | Convert HTML/CSS to a DOCX. |

--- a/Clippit.Tests/Cli/Integration/Word/WordConsolidateTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordConsolidateTests.cs
@@ -360,6 +360,7 @@ internal sealed class WordConsolidateTests : CliIntegrationTestBase
             .ConfigureAwait(false);
 
         await Assert.That(result.ExitCode).IsNotEqualTo(0);
+        await Assert.That(result.StandardError).Contains("stdin");
     }
 }
 #pragma warning restore CA1707

--- a/Clippit.Tests/Cli/Integration/Word/WordConsolidateTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordConsolidateTests.cs
@@ -351,5 +351,15 @@ internal sealed class WordConsolidateTests : CliIntegrationTestBase
         using var doc = WordprocessingDocument.Open(output.FullName, false);
         await Validate(doc, s_expectedErrors);
     }
+
+    [Test]
+    public async Task CLI178_WordConsolidate_StdinForRevision_ReturnsInvalidArguments()
+    {
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "consolidate", s_original, "-", "--output", Path.Combine(TempDir, "out.docx"))
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+    }
 }
 #pragma warning restore CA1707

--- a/Clippit.Tests/Cli/Integration/Word/WordConsolidateTests.cs
+++ b/Clippit.Tests/Cli/Integration/Word/WordConsolidateTests.cs
@@ -1,0 +1,355 @@
+using System.Text;
+using Clippit.Tests.Word;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Clippit.Tests.Cli.Integration.Word;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class WordConsolidateTests : CliIntegrationTestBase
+{
+    private static readonly string s_original = CliTestRunner.TestFile("WC/WC027-Twenty-Paras-Before.docx").FullName;
+    private static readonly string s_rev1 = CliTestRunner.TestFile("WC/WC027-Twenty-Paras-After-1.docx").FullName;
+    private static readonly string s_rev2 = CliTestRunner.TestFile("WC/WC027-Twenty-Paras-After-2.docx").FullName;
+    private static readonly string s_rev3 = CliTestRunner.TestFile("WC/WC027-Twenty-Paras-After-3.docx").FullName;
+
+    // WmlComparer.Consolidate produces tblLook attributes that reference conditional
+    // table-style attributes; these are pre-existing schema warnings from the comparer.
+    private static readonly List<string> s_expectedErrors = WmlComparerTests.ExpectedErrors.ToList();
+
+    [Test]
+    public async Task CLI164_WordConsolidate_SingleRevision_ProducesValidOutput()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-1rev.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "consolidate", s_original, s_rev1, "--output", output.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("original").GetString()).IsEqualTo(s_original);
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(output.FullName);
+        await Assert.That(json.RootElement.GetProperty("outputSize").GetInt64()).IsGreaterThan(0);
+        var revisions = json.RootElement.GetProperty("revisions");
+        await Assert.That(revisions.GetArrayLength()).IsEqualTo(1);
+        await Assert.That(revisions[0].GetProperty("file").GetString()).IsEqualTo(s_rev1);
+
+        await Assert.That(output.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI165_WordConsolidate_MultipleRevisions_ProducesValidOutput()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-3rev.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                s_rev1,
+                s_rev2,
+                s_rev3,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        var revisions = json.RootElement.GetProperty("revisions");
+        await Assert.That(revisions.GetArrayLength()).IsEqualTo(3);
+        await Assert.That(output.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI166_WordConsolidate_CustomRevisorAndColor_AppliedToResult()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-revisor.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                s_rev1,
+                "--revisor",
+                "Alice",
+                "--color",
+                "#FF0000",
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        var revisions = json.RootElement.GetProperty("revisions");
+        await Assert.That(revisions[0].GetProperty("revisor").GetString()).IsEqualTo("Alice");
+        await Assert.That(revisions[0].GetProperty("color").GetString()).IsEqualTo("#FF0000");
+        await Assert.That(output.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI167_WordConsolidate_NoTableConsolidation_ProducesValidOutput()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-notable.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                s_rev1,
+                "--no-table-consolidation",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI168_WordConsolidate_CaseInsensitive_ProducesValidOutput()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-ci.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                s_rev1,
+                "--case-insensitive",
+                "--output",
+                output.FullName
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI169_WordConsolidate_MismatchedRevisorCount_ReturnsInvalidArguments()
+    {
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                s_rev1,
+                s_rev2,
+                "--revisor",
+                "OnlyOne",
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(2);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("--revisor");
+    }
+
+    [Test]
+    public async Task CLI170_WordConsolidate_MismatchedColorCount_ReturnsInvalidArguments()
+    {
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                s_rev1,
+                s_rev2,
+                "--color",
+                "#FF0000",
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(2);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).Contains("--color");
+    }
+
+    [Test]
+    public async Task CLI171_WordConsolidate_NoRevisions_ReturnsInvalidArguments()
+    {
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                "--output",
+                Path.Combine(TempDir, "out.docx"),
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(2);
+        await Assert.That(result.StandardOutput).IsEmpty();
+    }
+
+    [Test]
+    public async Task CLI172_WordConsolidate_DefaultOutputNaming_UsesConsolidatedSuffix()
+    {
+        var originalCopy = new FileInfo(Path.Combine(TempDir, "source.docx"));
+        File.Copy(s_original, originalCopy.FullName);
+        var expectedOutput = new FileInfo(Path.Combine(TempDir, "source-consolidated.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "consolidate", originalCopy.FullName, s_rev1)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(expectedOutput.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(expectedOutput.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI173_WordConsolidate_QuietSuppressesStdout()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-quiet.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("word", "consolidate", s_original, s_rev1, "--output", output.FullName, "--quiet")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI174_WordConsolidate_NonExistentRevision_ReturnsFileNotFound()
+    {
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                "nonexistent-rev.docx",
+                "--output",
+                Path.Combine(TempDir, "out.docx")
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+    }
+
+    [Test]
+    public async Task CLI175_WordConsolidate_OriginalFromStdin_ProducesValidOutput()
+    {
+        var originalBytes = await File.ReadAllBytesAsync(s_original).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-stdin.docx"));
+
+        var binaryResult = await CliTestRunner
+            .RunManagedWithStdinAsync(
+                originalBytes,
+                "word",
+                "consolidate",
+                "-",
+                s_rev1,
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(binaryResult.ExitCode).IsEqualTo(0);
+        var stdout = Encoding.UTF8.GetString(binaryResult.StandardOutput);
+        using var json = System.Text.Json.JsonDocument.Parse(stdout);
+        await Assert.That(json.RootElement.GetProperty("original").GetString()).IsEqualTo("<stdin>");
+        await Assert.That(output.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI176_WordConsolidate_OutputToStdout_ProducesValidDocx()
+    {
+        var binaryResult = await CliTestRunner
+            .RunManagedWithStdinAsync([], "word", "consolidate", s_original, s_rev1, "--output", "-")
+            .ConfigureAwait(false);
+
+        await Assert.That(binaryResult.ExitCode).IsEqualTo(0);
+        await Assert.That(binaryResult.StandardOutput.Length).IsGreaterThan(0);
+
+        using var stream = new MemoryStream(binaryResult.StandardOutput);
+        using var doc = WordprocessingDocument.Open(stream, false);
+        await Validate(doc, s_expectedErrors);
+    }
+
+    [Test]
+    public async Task CLI177_WordConsolidate_TwoRevisorsAndColors_ReflectedInResult()
+    {
+        var output = new FileInfo(Path.Combine(TempDir, "consolidated-2rv.docx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(
+                "word",
+                "consolidate",
+                s_original,
+                s_rev1,
+                s_rev2,
+                "--revisor",
+                "Alice",
+                "--revisor",
+                "Bob",
+                "--color",
+                "#FF0000",
+                "--color",
+                "#0000FF",
+                "--output",
+                output.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        var revisions = json.RootElement.GetProperty("revisions");
+        await Assert.That(revisions.GetArrayLength()).IsEqualTo(2);
+        await Assert.That(revisions[0].GetProperty("revisor").GetString()).IsEqualTo("Alice");
+        await Assert.That(revisions[0].GetProperty("color").GetString()).IsEqualTo("#FF0000");
+        await Assert.That(revisions[1].GetProperty("revisor").GetString()).IsEqualTo("Bob");
+        await Assert.That(revisions[1].GetProperty("color").GetString()).IsEqualTo("#0000FF");
+        await Assert.That(output.Exists).IsTrue();
+        using var doc = WordprocessingDocument.Open(output.FullName, false);
+        await Validate(doc, s_expectedErrors);
+    }
+}
+#pragma warning restore CA1707

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -16,6 +16,7 @@ published for documentation, integration validation, and contract tests.
 | [`verify-result.v1.json`](./verify-result.v1.json)     | Stdout payload of `clippit pptx verify`, `clippit word verify`, `clippit excel verify` (JSON mode)                                                                          |
 | [`compare-result.v1.json`](./compare-result.v1.json)   | Stdout payload of `clippit word compare` (JSON mode)                                                                                                                        |
 | [`assemble-result.v1.json`](./assemble-result.v1.json) | Stdout payload of `clippit word assemble` (JSON mode)                                                                                                                       |
+| [`consolidate-result.v1.json`](./consolidate-result.v1.json) | Stdout payload of `clippit word consolidate` (JSON mode)                                                                                                            |
 | [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, `clippit word accept-revisions`, `clippit word simplify-markup`, or `clippit excel to-html` (JSON mode) |
 
 ## Output discipline

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -46,6 +46,10 @@ published for documentation, integration validation, and contract tests.
   reserved for the converted HTML/DOCX stream and the success payload is
   suppressed.
 
+  `word compare` and `word consolidate` follow the same pattern: when
+  `--output -` is used, stdout carries the binary DOCX and the JSON result is
+  suppressed.
+
 ## Exit codes
 
 | Code | Symbolic            | Meaning                                               |

--- a/docs/schemas/consolidate-result.v1.json
+++ b/docs/schemas/consolidate-result.v1.json
@@ -21,7 +21,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "description": "Absolute path of the revision file, or '<stdin>' when read from stdin."
+            "description": "Absolute path of the revision file."
           },
           "revisor": {
             "type": "string",
@@ -37,7 +37,7 @@
     },
     "output": {
       "type": "string",
-      "description": "Absolute path of the consolidated output file, or '<stdout>' when written to stdout."
+      "description": "Absolute path of the consolidated output file. When --output - is used, stdout is reserved for the binary DOCX stream and no JSON result is emitted."
     },
     "outputSize": {
       "type": "integer",

--- a/docs/schemas/consolidate-result.v1.json
+++ b/docs/schemas/consolidate-result.v1.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sergey-tihon.github.io/Clippit/schemas/consolidate-result.v1.json",
+  "title": "Clippit word consolidate result",
+  "description": "Result payload of `clippit word consolidate` written to stdout in JSON mode.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["original", "revisions", "output", "outputSize"],
+  "properties": {
+    "original": {
+      "type": "string",
+      "description": "Absolute path of the original .docx file, or '<stdin>' when read from stdin."
+    },
+    "revisions": {
+      "type": "array",
+      "description": "One entry per revision document.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["file", "revisor", "color"],
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Absolute path of the revision file, or '<stdin>' when read from stdin."
+          },
+          "revisor": {
+            "type": "string",
+            "description": "Reviewer name used for tracked revisions from this document."
+          },
+          "color": {
+            "type": "string",
+            "description": "Hex color (#RRGGBB) assigned to this reviewer's tracked changes.",
+            "pattern": "^#[0-9A-Fa-f]{6}$"
+          }
+        }
+      }
+    },
+    "output": {
+      "type": "string",
+      "description": "Absolute path of the consolidated output file, or '<stdout>' when written to stdout."
+    },
+    "outputSize": {
+      "type": "integer",
+      "description": "Size of the consolidated output .docx file in bytes."
+    }
+  }
+}

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -24,8 +24,26 @@ clippit pptx verify presentation.pptx
 # Validate a DOCX file
 clippit word verify document.docx
 
+# Compare two DOCX files with tracked revisions
+clippit word compare before.docx after.docx --output compared.docx
+
+# Consolidate multiple DOCX revisions into one tracked-changes file
+clippit word consolidate original.docx alice.docx bob.docx --output consolidated.docx
+
 # Assemble a DOCX template with XML data
 clippit word assemble template.docx data.xml --output assembled.docx
+
+# Accept all tracked revisions in a DOCX file
+clippit word accept-revisions draft.docx
+
+# Remove non-content markup from a DOCX file
+clippit word simplify-markup document.docx --accept-revisions --remove-comments
+
+# Convert DOCX to HTML
+clippit word to-html document.docx
+
+# Convert HTML to DOCX
+clippit word from-html article.html --css styles.css
 
 # Validate an XLSX file
 clippit excel verify spreadsheet.xlsx
@@ -44,7 +62,9 @@ clippit pptx split presentation.pptx --format json
 | `pptx verify`           | Validate a PPTX — schema, relationships, markup compatibility, and sections.                                                            |
 | `word assemble`         | Assemble a DOCX template with XML data.                                                                                                  |
 | `word compare`          | Compare two DOCX files and produce a tracked-revision DOCX.                                                                             |
+| `word consolidate`      | Combine multiple DOCX revisions into one tracked-changes DOCX.                                                                          |
 | `word accept-revisions` | Accept all tracked revisions in a DOCX file.                                                                                            |
+| `word simplify-markup`  | Remove non-content markup from a DOCX file.                                                                                             |
 | `word verify`           | Validate a DOCX — schema and relationships.                                                                                             |
 | `word to-html`    | Convert a DOCX to HTML/CSS.                                                                                                             |
 | `word from-html`  | Convert HTML/CSS to a DOCX.                                                                                                             |


### PR DESCRIPTION
Implements the `word consolidate` CLI command wrapping WmlComparer.Consolidate.

Features:
- Accepts an original document and one or more revision files as positional args
- Supports --revisor / --color options (one per revision, cycle defaults if omitted)
- --author, --date-time, --case-insensitive options map to WmlComparerSettings
- --no-table-consolidation disables WmlComparerConsolidateSettings.ConsolidateWithTable
- --output/-o for destination path (default: <original>-consolidated.docx, - for stdout)
- --force to overwrite existing output; --format json; --quiet
- Stdin support (-) for original document
- Validates revisor/color counts match revision count; returns INVALID_ARGUMENTS on mismatch
- Emits ConsolidateResult payload (original, revisions array, output, outputSize)
- AOT-safe: all types registered in CliJsonContext with [JsonSerializable]

Tests: 14 integration tests (CLI164-CLI177) covering success paths, stdout output,
json format, stdin input, custom colors/revisors, table consolidation toggle, stdin
conflict detection, and error cases (missing file, invalid color, count mismatch).

Schema: docs/schemas/consolidate-result.v1.json

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
