### PR TITLE
[Clippy] feat(cli): add `clippit excel create` command

### DIFF
--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [0.7.0] - 2026-07-05
 
+- Added `excel create` command to generate an `.xlsx` workbook from a JSON workbook
+  definition. Wraps `SpreadsheetWriter`/`WorkbookDfn`. Supports one positional input
+  argument (`-` for stdin). Options: `--output`/`-o` (defaults to `<input>.xlsx`,
+  `-` for stdout), `--force`, `--format json`, `--quiet`. The JSON result reports
+  `input`, `output`, `outputSize`, and `worksheetCount`. Invalid sheet names or
+  duplicate worksheet names return `INVALID_ARGUMENTS` (exit 2). Published schemas:
+  `workbook-definition.v1.json` (input) and `excel-create-result.v1.json` (result)
+  (#378).
 - Added `word consolidate` command to combine multiple revisions of a document into one
   file with tracked changes. Wraps `WmlComparer.Consolidate`. Supports one positional
   original argument and one or more revision arguments. Reviewer names and hex colors

--- a/Clippit.Cli/CliJsonContext.cs
+++ b/Clippit.Cli/CliJsonContext.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Clippit.Cli.Commands.Common.Verify;
+using Clippit.Cli.Commands.Excel.Create;
 using Clippit.Cli.Commands.Pptx.Build;
 using Clippit.Cli.Commands.Pptx.Split;
 using Clippit.Cli.Commands.Pptx.Verify;
@@ -34,6 +35,8 @@ namespace Clippit.Cli;
 [JsonSerializable(typeof(AssembleResult))]
 [JsonSerializable(typeof(ConsolidateResult))]
 [JsonSerializable(typeof(IReadOnlyList<RevisionInfoResult>))]
+[JsonSerializable(typeof(WorkbookDefinition))]
+[JsonSerializable(typeof(CreateResult))]
 [JsonSerializable(typeof(ErrorResult))]
 [JsonSourceGenerationOptions(
     WriteIndented = false,

--- a/Clippit.Cli/Commands/Excel/Create/CreateResult.cs
+++ b/Clippit.Cli/Commands/Excel/Create/CreateResult.cs
@@ -1,0 +1,17 @@
+namespace Clippit.Cli.Commands.Excel.Create;
+
+internal sealed record CreateResult
+{
+    public required string Input { get; init; }
+    public required string Output { get; init; }
+    public required long OutputSize { get; init; }
+    public required int WorksheetCount { get; init; }
+
+    public static void WriteText(CreateResult result, TextWriter writer)
+    {
+        writer.WriteLine($"Input: {result.Input}");
+        writer.WriteLine($"Output: {result.Output}");
+        writer.WriteLine($"Output size: {result.OutputSize} bytes");
+        writer.WriteLine($"Worksheets: {result.WorksheetCount}");
+    }
+}

--- a/Clippit.Cli/Commands/Excel/Create/ExcelCreateCommand.cs
+++ b/Clippit.Cli/Commands/Excel/Create/ExcelCreateCommand.cs
@@ -1,0 +1,73 @@
+using System.CommandLine;
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Excel.Create;
+
+internal static class ExcelCreateCommand
+{
+    public static Command Build()
+    {
+        var inputArg = InputSource.BuildArgument(
+            "input",
+            "Path to the workbook definition JSON file. Use '-' to read from stdin."
+        );
+
+        var outputOption = new Option<string?>("--output", "-o")
+        {
+            Description =
+                "Output path for the generated .xlsx file. "
+                + "Defaults to the input file name with '.xlsx' extension. "
+                + "Use '-' to write binary content to stdout.",
+        };
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Overwrite the output file if it already exists.",
+        };
+
+        var cmd = new Command(
+            "create",
+            "Generate an Excel (.xlsx) workbook from a JSON workbook definition."
+                + "\n\nExamples:"
+                + "\n  clippit excel create report.json"
+                + "\n  clippit excel create report.json --output report.xlsx --format json"
+                + "\n  cat report.json | clippit excel create - --output report.xlsx"
+                + "\n  clippit excel create report.json --output - > report.xlsx"
+        );
+        cmd.Arguments.Add(inputArg);
+        cmd.Options.Add(outputOption);
+        cmd.Options.Add(forceOption);
+        var (formatOption, quietOption) = cmd.AddOutputOptions();
+
+        cmd.SetAction(parseResult =>
+            CommandRunner.Execute(() =>
+                Run(
+                    parseResult.GetValue(inputArg)!,
+                    parseResult.GetValue(outputOption),
+                    parseResult.GetValue(forceOption),
+                    parseResult.GetValue(formatOption),
+                    parseResult.GetValue(quietOption)
+                )
+            )
+        );
+
+        return cmd;
+    }
+
+    private static int Run(string inputPath, string? outputPath, bool force, OutputFormat format, bool quiet)
+    {
+        var input = InputSource.From(inputPath, "stdin-workbook.json");
+        var defaultOutput = input.IsStdin
+            ? "workbook.xlsx"
+            : Path.Combine(
+                Path.GetDirectoryName(input.DisplayName)!,
+                Path.GetFileNameWithoutExtension(input.DisplayName) + ".xlsx"
+            );
+        var output = OutputTarget.FromOption(outputPath, () => defaultOutput);
+        var writer = new OutputWriter(format, quiet || output.IsStdout);
+
+        var result = ExcelCreateService.Execute(input, output, force);
+        writer.WriteResult(result, CliJsonContext.Default.CreateResult, CreateResult.WriteText);
+        return ExitCodes.Success;
+    }
+}

--- a/Clippit.Cli/Commands/Excel/Create/ExcelCreateService.cs
+++ b/Clippit.Cli/Commands/Excel/Create/ExcelCreateService.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using Clippit.Cli.Infrastructure;
+using Clippit.Excel;
+
+namespace Clippit.Cli.Commands.Excel.Create;
+
+internal static class ExcelCreateService
+{
+    public static CreateResult Execute(InputSource input, OutputTarget output, bool force)
+    {
+        WorkbookDefinition definition;
+        try
+        {
+            using var stream = input.OpenSeekable();
+            definition =
+                JsonSerializer.Deserialize(stream, CliJsonContext.Default.WorkbookDefinition)
+                ?? throw CliException.InvalidFormat("Workbook definition JSON is null.");
+        }
+        catch (JsonException ex)
+        {
+            throw CliException.InvalidFormat($"Invalid workbook definition JSON: {ex.Message}");
+        }
+
+        if (definition.Worksheets.Count == 0)
+            throw CliException.InvalidArguments("Workbook definition must contain at least one worksheet.");
+
+        var workbook = MapWorkbook(definition);
+
+        var memStream = new MemoryStream();
+        try
+        {
+            workbook.WriteTo(memStream);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.InvalidFormat($"Could not generate workbook: {ex.Message}");
+        }
+
+        var bytes = memStream.ToArray();
+
+        string? tempPath = null;
+        try
+        {
+            output.EnsureCanWrite(force, "output");
+            output.EnsureDirectoryExists();
+            using (var outStream = output.OpenWrite(out tempPath))
+            {
+                outStream.Write(bytes, 0, bytes.Length);
+                outStream.Flush();
+
+                if (output.IsStdout)
+                    output.Flush(outStream);
+            }
+
+            if (!output.IsStdout)
+                output.Commit(tempPath);
+        }
+        catch (Exception ex) when (ex is not CliException)
+        {
+            throw CliException.OutputError($"Could not write output: {ex.Message}");
+        }
+        finally
+        {
+            OutputTarget.DeleteTemp(tempPath);
+        }
+
+        return new CreateResult
+        {
+            Input = input.DisplayName,
+            Output = output.DisplayPath,
+            OutputSize = bytes.Length,
+            WorksheetCount = definition.Worksheets.Count,
+        };
+    }
+
+    private static WorkbookDfn MapWorkbook(WorkbookDefinition definition) =>
+        new() { Worksheets = definition.Worksheets.Select(MapWorksheet).ToList() };
+
+    private static WorksheetDfn MapWorksheet(WorksheetDefinition ws)
+    {
+        var dfn = new WorksheetDfn
+        {
+            Name = ws.Name,
+            Rows = ws.Rows.Select(r => new RowDfn { Cells = r.Cells.Select(MapCell).ToList() }).ToList(),
+        };
+        // TableName and ColumnHeadings are optional in WorksheetDfn (legacy API accepts null)
+        if (ws.TableName is not null)
+            dfn.TableName = ws.TableName;
+        if (ws.ColumnHeadings is not null)
+            dfn.ColumnHeadings = ws.ColumnHeadings.Select(MapCell).ToList();
+        return dfn;
+    }
+
+    private static CellDfn MapCell(CellDefinition cell)
+    {
+        var dataType = MapCellDataType(cell.CellDataType);
+        var dfn = new CellDfn
+        {
+            // CellDfn is a legacy class; null assignments are safe at runtime
+            Value = ConvertValue(cell.Value, dataType),
+            CellDataType = dataType,
+            HorizontalCellAlignment = MapAlignment(cell.HorizontalCellAlignment),
+            Bold = cell.Bold,
+            Italic = cell.Italic,
+        };
+        if (cell.FormatCode is not null)
+            dfn.FormatCode = cell.FormatCode;
+        return dfn;
+    }
+
+    private static object ConvertValue(System.Text.Json.JsonElement? element, CellDataType? dataType)
+    {
+        if (element is null)
+            return string.Empty;
+
+        return element.Value.ValueKind switch
+        {
+            System.Text.Json.JsonValueKind.Null => string.Empty,
+            System.Text.Json.JsonValueKind.True => true,
+            System.Text.Json.JsonValueKind.False => false,
+            System.Text.Json.JsonValueKind.Number => element.Value.GetDouble(),
+            System.Text.Json.JsonValueKind.String => ParseStringValue(
+                element.Value.GetString() ?? string.Empty,
+                dataType
+            ),
+            _ => string.Empty,
+        };
+    }
+
+    private static object ParseStringValue(string value, CellDataType? dataType)
+    {
+        if (
+            dataType == CellDataType.Date
+            && DateTime.TryParse(value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt)
+        )
+            return dt;
+
+        return value;
+    }
+
+    private static CellDataType? MapCellDataType(CellDataTypeJson? json) =>
+        json switch
+        {
+            CellDataTypeJson.Boolean => CellDataType.Boolean,
+            CellDataTypeJson.Date => CellDataType.Date,
+            CellDataTypeJson.Number => CellDataType.Number,
+            CellDataTypeJson.String => CellDataType.String,
+            _ => null,
+        };
+
+    private static HorizontalCellAlignment? MapAlignment(HorizontalAlignmentJson? json) =>
+        json switch
+        {
+            HorizontalAlignmentJson.Left => HorizontalCellAlignment.Left,
+            HorizontalAlignmentJson.Center => HorizontalCellAlignment.Center,
+            HorizontalAlignmentJson.Right => HorizontalCellAlignment.Right,
+            _ => null,
+        };
+}

--- a/Clippit.Cli/Commands/Excel/Create/ExcelCreateService.cs
+++ b/Clippit.Cli/Commands/Excel/Create/ExcelCreateService.cs
@@ -21,7 +21,7 @@ internal static class ExcelCreateService
             throw CliException.InvalidFormat($"Invalid workbook definition JSON: {ex.Message}");
         }
 
-        if (definition.Worksheets.Count == 0)
+        if (definition.Worksheets is null || definition.Worksheets.Count == 0)
             throw CliException.InvalidArguments("Workbook definition must contain at least one worksheet.");
 
         var workbook = MapWorkbook(definition);
@@ -31,12 +31,17 @@ internal static class ExcelCreateService
         {
             workbook.WriteTo(memStream);
         }
+        catch (Exception ex) when (ex is InvalidSheetNameException or WorksheetAlreadyExistsException)
+        {
+            throw CliException.InvalidArguments(ex.Message);
+        }
         catch (Exception ex) when (ex is not CliException)
         {
             throw CliException.InvalidFormat($"Could not generate workbook: {ex.Message}");
         }
 
-        var bytes = memStream.ToArray();
+        var outputSize = memStream.Length;
+        memStream.Position = 0;
 
         string? tempPath = null;
         try
@@ -45,7 +50,7 @@ internal static class ExcelCreateService
             output.EnsureDirectoryExists();
             using (var outStream = output.OpenWrite(out tempPath))
             {
-                outStream.Write(bytes, 0, bytes.Length);
+                memStream.CopyTo(outStream);
                 outStream.Flush();
 
                 if (output.IsStdout)
@@ -68,7 +73,7 @@ internal static class ExcelCreateService
         {
             Input = input.DisplayName,
             Output = output.DisplayPath,
-            OutputSize = bytes.Length,
+            OutputSize = outputSize,
             WorksheetCount = definition.Worksheets.Count,
         };
     }
@@ -81,12 +86,14 @@ internal static class ExcelCreateService
         var dfn = new WorksheetDfn
         {
             Name = ws.Name,
-            Rows = ws.Rows.Select(r => new RowDfn { Cells = r.Cells.Select(MapCell).ToList() }).ToList(),
+            Rows = (ws.Rows ?? [])
+                .Select(r => new RowDfn { Cells = (r.Cells ?? []).Select(MapCell).ToList() })
+                .ToList(),
         };
         // TableName and ColumnHeadings are optional in WorksheetDfn (legacy API accepts null)
         if (ws.TableName is not null)
             dfn.TableName = ws.TableName;
-        if (ws.ColumnHeadings is not null)
+        if (ws.ColumnHeadings is { Count: > 0 })
             dfn.ColumnHeadings = ws.ColumnHeadings.Select(MapCell).ToList();
         return dfn;
     }
@@ -131,7 +138,12 @@ internal static class ExcelCreateService
     {
         if (
             dataType == CellDataType.Date
-            && DateTime.TryParse(value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var dt)
+            && DateTime.TryParse(
+                value,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind,
+                out var dt
+            )
         )
             return dt;
 

--- a/Clippit.Cli/Commands/Excel/Create/WorkbookDefinition.cs
+++ b/Clippit.Cli/Commands/Excel/Create/WorkbookDefinition.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Clippit.Cli.Commands.Excel.Create;
+
+internal sealed class WorkbookDefinition
+{
+    public List<WorksheetDefinition> Worksheets { get; set; } = [];
+}
+
+internal sealed class WorksheetDefinition
+{
+    public required string Name { get; set; }
+    public string? TableName { get; set; }
+    public List<CellDefinition>? ColumnHeadings { get; set; }
+    public List<RowDefinition> Rows { get; set; } = [];
+}
+
+internal sealed class RowDefinition
+{
+    public List<CellDefinition> Cells { get; set; } = [];
+}
+
+/// <summary>
+/// JSON representation of a spreadsheet cell. <see cref="Value"/> is a raw
+/// <see cref="JsonElement"/> so it can hold string, number, boolean, or null
+/// without a custom AOT converter.
+/// </summary>
+internal sealed class CellDefinition
+{
+    public JsonElement? Value { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter<CellDataTypeJson>))]
+    public CellDataTypeJson? CellDataType { get; set; }
+
+    public string? FormatCode { get; set; }
+
+    [JsonConverter(typeof(JsonStringEnumConverter<HorizontalAlignmentJson>))]
+    public HorizontalAlignmentJson? HorizontalCellAlignment { get; set; }
+
+    public bool? Bold { get; set; }
+    public bool? Italic { get; set; }
+}
+
+internal enum CellDataTypeJson
+{
+    Boolean,
+    Date,
+    Number,
+    String,
+}
+
+internal enum HorizontalAlignmentJson
+{
+    Left,
+    Center,
+    Right,
+}

--- a/Clippit.Cli/Commands/Excel/ExcelCommand.cs
+++ b/Clippit.Cli/Commands/Excel/ExcelCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using Clippit.Cli.Commands.Excel.Create;
 using Clippit.Cli.Commands.Excel.ToHtml;
 using Clippit.Cli.Commands.Excel.Verify;
 
@@ -14,6 +15,7 @@ internal static class ExcelCommand
         var cmd = new Command("excel", "Work with Excel (.xlsx) files");
         cmd.Subcommands.Add(ExcelVerifyCommand.Build());
         cmd.Subcommands.Add(ExcelToHtmlCommand.Build());
+        cmd.Subcommands.Add(ExcelCreateCommand.Build());
         return cmd;
     }
 }

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -47,6 +47,9 @@ clippit word from-html article.html --css styles.css
 # Validate an XLSX file
 clippit excel verify spreadsheet.xlsx
 
+# Create an XLSX workbook from a JSON definition
+clippit excel create workbook.json --output report.xlsx
+
 # Get JSON output for scripting
 clippit pptx split presentation.pptx --format json
 ```
@@ -68,6 +71,7 @@ clippit pptx split presentation.pptx --format json
 | `word to-html` | Convert a DOCX to HTML/CSS. |
 | `word from-html` | Convert HTML/CSS to a DOCX. |
 | `excel to-html` | Convert an XLSX sheet, range, or table to HTML/CSS. |
+| `excel create` | Generate an `.xlsx` workbook from a JSON workbook definition. |
 | `excel verify` | Validate an XLSX — schema and relationships. |
 | `version` | Print version information. |
 

--- a/Clippit.Tests/Cli/Integration/Excel/ExcelCreateTests.cs
+++ b/Clippit.Tests/Cli/Integration/Excel/ExcelCreateTests.cs
@@ -353,7 +353,7 @@ internal sealed class ExcelCreateTests : CliIntegrationTestBase
     }
 
     [Test]
-    public async Task CLI192_ExcelCreate_QuietMode_SupressesPayload()
+    public async Task CLI192_ExcelCreate_QuietMode_SuppressesPayload()
     {
         var dir = CliTestRunner.CreateTempDirectory("excel-create-quiet");
         var input = await WriteWorkbookJsonAsync(dir, SimpleWorkbook()).ConfigureAwait(false);
@@ -367,6 +367,29 @@ internal sealed class ExcelCreateTests : CliIntegrationTestBase
         await Assert.That(result.StandardOutput).IsEmpty();
         await Assert.That(result.StandardError).IsEmpty();
         await Assert.That(output.Exists).IsTrue();
+    }
+
+    [Test]
+    public async Task CLI193_ExcelCreate_InvalidSheetName_ReturnsInvalidArguments()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-invalid-sheet");
+        var content = """
+            {
+              "worksheets": [
+                {
+                  "name": "Bad/Name",
+                  "rows": [{ "cells": [{ "value": "x" }] }]
+                }
+              ]
+            }
+            """;
+        var input = await WriteWorkbookJsonAsync(dir, content).ConfigureAwait(false);
+
+        var result = await CliTestRunner.RunManagedAsync("excel", "create", input.FullName).ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(2);
+        using var json = result.ReadStderrJson();
+        await Assert.That(json.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_ARGUMENTS");
     }
 }
 #pragma warning restore CA1707

--- a/Clippit.Tests/Cli/Integration/Excel/ExcelCreateTests.cs
+++ b/Clippit.Tests/Cli/Integration/Excel/ExcelCreateTests.cs
@@ -1,0 +1,372 @@
+using System.Text;
+using System.Text.Json;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace Clippit.Tests.Cli.Integration.Excel;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class ExcelCreateTests : CliIntegrationTestBase
+{
+    private static string SimpleWorkbook(string sheetName = "Sheet1") =>
+        $$"""
+            {
+              "worksheets": [
+                {
+                  "name": "{{sheetName}}",
+                  "rows": [
+                    { "cells": [{ "value": "Hello" }, { "value": 42, "cellDataType": "Number" }] },
+                    { "cells": [{ "value": "World" }, { "value": 3.14, "cellDataType": "Number" }] }
+                  ]
+                }
+              ]
+            }
+            """;
+
+    private static string WorkbookWithTable() =>
+        """
+            {
+              "worksheets": [
+                {
+                  "name": "Sales",
+                  "tableName": "SalesTable",
+                  "columnHeadings": [
+                    { "value": "Product", "bold": true },
+                    { "value": "Revenue", "bold": true }
+                  ],
+                  "rows": [
+                    { "cells": [{ "value": "Widget" }, { "value": 1234.5, "cellDataType": "Number", "formatCode": "#,##0.00", "horizontalCellAlignment": "Right" }] },
+                    { "cells": [{ "value": "Gadget" }, { "value": 567.8, "cellDataType": "Number", "formatCode": "#,##0.00", "horizontalCellAlignment": "Right" }] }
+                  ]
+                }
+              ]
+            }
+            """;
+
+    private static async Task<FileInfo> WriteWorkbookJsonAsync(
+        DirectoryInfo dir,
+        string content,
+        string name = "workbook.json"
+    )
+    {
+        var file = new FileInfo(Path.Combine(dir.FullName, name));
+        await File.WriteAllTextAsync(file.FullName, content).ConfigureAwait(false);
+        return file;
+    }
+
+    private async Task ValidateXlsxAsync(FileInfo xlsx)
+    {
+        using var doc = DocumentFormat.OpenXml.Packaging.SpreadsheetDocument.Open(xlsx.FullName, false);
+        await Validate(doc, []);
+    }
+
+    [Test]
+    public async Task CLI179_ExcelCreate_ValidDefinition_ProducesValidXlsx()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-basic");
+        var input = await WriteWorkbookJsonAsync(dir, SimpleWorkbook()).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "output.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo(input.FullName);
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(output.FullName);
+        await Assert.That(json.RootElement.GetProperty("outputSize").GetInt64()).IsGreaterThan(0);
+        await Assert.That(json.RootElement.GetProperty("worksheetCount").GetInt32()).IsEqualTo(1);
+        await ValidateXlsxAsync(output).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task CLI180_ExcelCreate_MultipleWorksheets_AllWritten()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-multi");
+        var content = """
+            {
+              "worksheets": [
+                {
+                  "name": "Alpha",
+                  "rows": [{ "cells": [{ "value": "A1" }] }]
+                },
+                {
+                  "name": "Beta",
+                  "rows": [{ "cells": [{ "value": "B1" }] }]
+                },
+                {
+                  "name": "Gamma",
+                  "rows": [{ "cells": [{ "value": "C1" }] }]
+                }
+              ]
+            }
+            """;
+        var input = await WriteWorkbookJsonAsync(dir, content).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "multi.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("worksheetCount").GetInt32()).IsEqualTo(3);
+
+        using var doc = DocumentFormat.OpenXml.Packaging.SpreadsheetDocument.Open(output.FullName, false);
+        var sheets = doc.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().Select(s => s.Name?.Value).ToList();
+        await Assert.That(sheets).Contains("Alpha");
+        await Assert.That(sheets).Contains("Beta");
+        await Assert.That(sheets).Contains("Gamma");
+    }
+
+    [Test]
+    public async Task CLI181_ExcelCreate_WithTableAndColumnHeadings_ProducesValidXlsx()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-table");
+        var input = await WriteWorkbookJsonAsync(dir, WorkbookWithTable()).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "table.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await ValidateXlsxAsync(output).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task CLI182_ExcelCreate_DateCellType_ParsesIso8601()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-date");
+        var content = """
+            {
+              "worksheets": [
+                {
+                  "name": "Dates",
+                  "rows": [
+                    { "cells": [
+                      { "value": "2026-07-09", "cellDataType": "Date", "formatCode": "yyyy-mm-dd" }
+                    ]}
+                  ]
+                }
+              ]
+            }
+            """;
+        var input = await WriteWorkbookJsonAsync(dir, content).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "dates.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await ValidateXlsxAsync(output).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task CLI183_ExcelCreate_BooleanCell_Accepted()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-bool");
+        var content = """
+            {
+              "worksheets": [
+                {
+                  "name": "Flags",
+                  "rows": [
+                    { "cells": [
+                      { "value": true, "cellDataType": "Boolean" },
+                      { "value": false, "cellDataType": "Boolean" }
+                    ]}
+                  ]
+                }
+              ]
+            }
+            """;
+        var input = await WriteWorkbookJsonAsync(dir, content).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "bools.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await ValidateXlsxAsync(output).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task CLI184_ExcelCreate_NullCellValue_TreatedAsEmpty()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-null");
+        var content = """
+            {
+              "worksheets": [
+                {
+                  "name": "NullsSheet",
+                  "rows": [
+                    { "cells": [{ "value": null }, { "value": "present" }] }
+                  ]
+                }
+              ]
+            }
+            """;
+        var input = await WriteWorkbookJsonAsync(dir, content).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "nulls.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await ValidateXlsxAsync(output).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task CLI185_ExcelCreate_DefaultOutputPath_AdjacentToInput()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-default-out");
+        var input = await WriteWorkbookJsonAsync(dir, SimpleWorkbook(), "report.json").ConfigureAwait(false);
+        var expectedOutput = new FileInfo(Path.Combine(dir.FullName, "report.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(expectedOutput.Exists).IsTrue();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("output").GetString()).IsEqualTo(expectedOutput.FullName);
+    }
+
+    [Test]
+    public async Task CLI186_ExcelCreate_StdinInput_DefaultsToWorkbookXlsx()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-stdin");
+        var outputFile = new FileInfo(Path.Combine(dir.FullName, "from-stdin.xlsx"));
+        var jsonBytes = Encoding.UTF8.GetBytes(SimpleWorkbook());
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync(
+                jsonBytes,
+                "excel",
+                "create",
+                "-",
+                "--output",
+                outputFile.FullName,
+                "--format",
+                "json"
+            )
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(outputFile.Exists).IsTrue();
+
+        using var json = JsonDocument.Parse(result.StandardOutput);
+        await Assert.That(json.RootElement.GetProperty("input").GetString()).IsEqualTo("<stdin>");
+    }
+
+    [Test]
+    public async Task CLI187_ExcelCreate_StdoutOutput_WritesBinaryToStdout()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-stdout");
+        var input = await WriteWorkbookJsonAsync(dir, SimpleWorkbook()).ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedWithStdinAsync([], "excel", "create", input.FullName, "--output", "-")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        // xlsx files start with PK magic bytes (ZIP)
+        await Assert.That(result.StandardOutput.Length).IsGreaterThan(0);
+        await Assert.That(result.StandardOutput[0]).IsEqualTo((byte)'P');
+        await Assert.That(result.StandardOutput[1]).IsEqualTo((byte)'K');
+    }
+
+    [Test]
+    public async Task CLI188_ExcelCreate_OutputExists_FailsWithoutForce()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-overwrite");
+        var input = await WriteWorkbookJsonAsync(dir, SimpleWorkbook()).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "existing.xlsx"));
+        await File.WriteAllTextAsync(output.FullName, "placeholder").ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName)
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsNotEqualTo(0);
+        await Assert.That(result.StandardError).Contains("already exists");
+    }
+
+    [Test]
+    public async Task CLI189_ExcelCreate_OutputExistsWithForce_Overwrites()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-force");
+        var input = await WriteWorkbookJsonAsync(dir, SimpleWorkbook()).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "overwrite.xlsx"));
+        await File.WriteAllTextAsync(output.FullName, "placeholder").ConfigureAwait(false);
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName, "--force")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await ValidateXlsxAsync(output).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task CLI190_ExcelCreate_MalformedJson_ReturnsInvalidFormat()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-invalid-json");
+        var input = new FileInfo(Path.Combine(dir.FullName, "bad.json"));
+        await File.WriteAllTextAsync(input.FullName, "{ not valid json }").ConfigureAwait(false);
+
+        var result = await CliTestRunner.RunManagedAsync("excel", "create", input.FullName).ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(4);
+        using var json = result.ReadStderrJson();
+        await Assert.That(json.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_FORMAT");
+    }
+
+    [Test]
+    public async Task CLI191_ExcelCreate_EmptyWorksheets_ReturnsInvalidArguments()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-empty");
+        var content = """{ "worksheets": [] }""";
+        var input = await WriteWorkbookJsonAsync(dir, content).ConfigureAwait(false);
+
+        var result = await CliTestRunner.RunManagedAsync("excel", "create", input.FullName).ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(2);
+        using var json = result.ReadStderrJson();
+        await Assert.That(json.RootElement.GetProperty("code").GetString()).IsEqualTo("INVALID_ARGUMENTS");
+    }
+
+    [Test]
+    public async Task CLI192_ExcelCreate_QuietMode_SupressesPayload()
+    {
+        var dir = CliTestRunner.CreateTempDirectory("excel-create-quiet");
+        var input = await WriteWorkbookJsonAsync(dir, SimpleWorkbook()).ConfigureAwait(false);
+        var output = new FileInfo(Path.Combine(dir.FullName, "quiet.xlsx"));
+
+        var result = await CliTestRunner
+            .RunManagedAsync("excel", "create", input.FullName, "--output", output.FullName, "--quiet")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardOutput).IsEmpty();
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert.That(output.Exists).IsTrue();
+    }
+}
+#pragma warning restore CA1707

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -11,12 +11,14 @@ published for documentation, integration validation, and contract tests.
 | File                                                   | What it describes                                                                                                                                                           |
 | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`deck-manifest.v1.json`](./deck-manifest.v1.json)     | Input manifest consumed by `clippit pptx build run`                                                                                                                         |
+| [`workbook-definition.v1.json`](./workbook-definition.v1.json) | Input document consumed by `clippit excel create`                                                                                                                   |
 | [`split-result.v1.json`](./split-result.v1.json)       | Stdout payload of `clippit pptx split` (JSON mode)                                                                                                                          |
 | [`build-result.v1.json`](./build-result.v1.json)       | Stdout payload of `clippit pptx build run` (JSON mode)                                                                                                                      |
 | [`verify-result.v1.json`](./verify-result.v1.json)     | Stdout payload of `clippit pptx verify`, `clippit word verify`, `clippit excel verify` (JSON mode)                                                                          |
 | [`compare-result.v1.json`](./compare-result.v1.json)   | Stdout payload of `clippit word compare` (JSON mode)                                                                                                                        |
 | [`assemble-result.v1.json`](./assemble-result.v1.json) | Stdout payload of `clippit word assemble` (JSON mode)                                                                                                                       |
 | [`consolidate-result.v1.json`](./consolidate-result.v1.json) | Stdout payload of `clippit word consolidate` (JSON mode)                                                                                                            |
+| [`excel-create-result.v1.json`](./excel-create-result.v1.json) | Stdout payload of `clippit excel create` (JSON mode)                                                                                                              |
 | [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, `clippit word accept-revisions`, `clippit word simplify-markup`, or `clippit excel to-html` (JSON mode) |
 
 ## Output discipline

--- a/docs/schemas/excel-create-result.v1.json
+++ b/docs/schemas/excel-create-result.v1.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sergey-tihon.github.io/Clippit/schemas/excel-create-result.v1.json",
+  "title": "ExcelCreateResult",
+  "description": "Stdout payload of `clippit excel create` (JSON mode).",
+  "type": "object",
+  "required": ["input", "output", "outputSize", "worksheetCount"],
+  "additionalProperties": false,
+  "properties": {
+    "input": {
+      "type": "string",
+      "description": "Absolute path to the input JSON file, or \"<stdin>\"."
+    },
+    "output": {
+      "type": "string",
+      "description": "Absolute path to the generated .xlsx file, or \"<stdout>\"."
+    },
+    "outputSize": {
+      "type": "integer",
+      "description": "Size of the generated .xlsx file in bytes.",
+      "minimum": 0
+    },
+    "worksheetCount": {
+      "type": "integer",
+      "description": "Number of worksheets written to the workbook.",
+      "minimum": 1
+    }
+  }
+}

--- a/docs/schemas/workbook-definition.v1.json
+++ b/docs/schemas/workbook-definition.v1.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sergey-tihon.github.io/Clippit/schemas/workbook-definition.v1.json",
+  "title": "WorkbookDefinition",
+  "description": "Input document consumed by `clippit excel create`.",
+  "type": "object",
+  "required": ["worksheets"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor validation."
+    },
+    "worksheets": {
+      "type": "array",
+      "description": "One or more worksheets to include in the workbook.",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/worksheet" }
+    }
+  },
+  "$defs": {
+    "worksheet": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Sheet name. Must be ≤31 characters and must not contain * [ ] / \\ : ?",
+          "maxLength": 31
+        },
+        "tableName": {
+          "type": "string",
+          "description": "Optional Excel table name. A table is created when columnHeadings is non-empty and rows is non-empty."
+        },
+        "columnHeadings": {
+          "type": "array",
+          "description": "Optional header row cells, formatted bold by default.",
+          "items": { "$ref": "#/$defs/cell" }
+        },
+        "rows": {
+          "type": "array",
+          "description": "Data rows.",
+          "items": { "$ref": "#/$defs/row" }
+        }
+      }
+    },
+    "row": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cells": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/cell" }
+        }
+      }
+    },
+    "cell": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "description": "Cell value. String, number, boolean, or null.",
+          "type": ["string", "number", "boolean", "null"]
+        },
+        "cellDataType": {
+          "type": "string",
+          "description": "Explicit data type hint.",
+          "enum": ["Boolean", "Date", "Number", "String"]
+        },
+        "formatCode": {
+          "type": "string",
+          "description": "Excel number-format string (e.g. \"#,##0.00\", \"yyyy-mm-dd\")."
+        },
+        "horizontalCellAlignment": {
+          "type": "string",
+          "description": "Horizontal alignment of the cell content.",
+          "enum": ["Left", "Center", "Right"]
+        },
+        "bold": {
+          "type": "boolean",
+          "description": "Bold text."
+        },
+        "italic": {
+          "type": "boolean",
+          "description": "Italic text."
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/workbook-definition.v1.json
+++ b/docs/schemas/workbook-definition.v1.json
@@ -26,8 +26,10 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Sheet name. Must be ≤31 characters and must not contain * [ ] / \\ : ?",
-          "maxLength": 31
+          "description": "Sheet name. Must be ≤31 characters, must not start with ' (apostrophe), and must not contain * [ ] / \\ : ?",
+          "minLength": 1,
+          "maxLength": 31,
+          "pattern": "^(?!')[^*\\[\\]/\\\\:?]+$"
         },
         "tableName": {
           "type": "string",

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -48,6 +48,9 @@ clippit word from-html article.html --css styles.css
 # Validate an XLSX file
 clippit excel verify spreadsheet.xlsx
 
+# Create an XLSX workbook from a JSON definition
+clippit excel create workbook.json --output report.xlsx
+
 # Get JSON output for scripting
 clippit pptx split presentation.pptx --format json
 ```
@@ -69,6 +72,7 @@ clippit pptx split presentation.pptx --format json
 | `word to-html`    | Convert a DOCX to HTML/CSS.                                                                                                             |
 | `word from-html`  | Convert HTML/CSS to a DOCX.                                                                                                             |
 | `excel to-html`   | Convert an XLSX sheet, range, or table to HTML/CSS.                                                                                     |
+| `excel create`    | Generate an `.xlsx` workbook from a JSON workbook definition.                                                                           |
 | `excel verify`    | Validate an XLSX — schema and relationships.                                                                                            |
 | `version`         | Print version information.                                                                                                              |
 


### PR DESCRIPTION
Implements the `clippit excel create` command (closes #378), which
generates an Excel (.xlsx) workbook from a JSON workbook definition,
using the existing SpreadsheetWriter infrastructure.

## New commands

### `clippit excel create <input> [--output <path>] [--force]`
Reads a JSON workbook definition, maps it to a WorkbookDfn, and
writes the result via WorkbookDfn.WriteTo(Stream).

- Stdin support (-) for pipe workflows
- Stdout binary output (--output -) for downstream processing
- --force to overwrite existing output
- Defaults output path to <input-base>.xlsx next to the input file

## JSON input format

Maps directly to WorkbookDfn/WorksheetDfn/RowDfn/CellDfn:
- worksheets[] with name, tableName, columnHeadings, rows
- cells with value (string/number/boolean/null), cellDataType,
  formatCode, horizontalCellAlignment, bold, italic
- Tables created when columnHeadings + rows both present

## New files

- Clippit.Cli/Commands/Excel/Create/ExcelCreateCommand.cs
- Clippit.Cli/Commands/Excel/Create/ExcelCreateService.cs
- Clippit.Cli/Commands/Excel/Create/WorkbookDefinition.cs
- Clippit.Cli/Commands/Excel/Create/CreateResult.cs
- docs/schemas/workbook-definition.v1.json
- docs/schemas/excel-create-result.v1.json

## Tests

14 integration tests (CLI179-CLI192) covering: basic creation,
multiple worksheets, table+column headings, date/boolean/null cells,
default output path, stdin input, stdout output, overwrite protection,
--force, malformed JSON, empty worksheets, and --quiet mode.

All 14 tests pass. Build: 0 errors. CSharpier: passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
