### PR TITLE
feat(cli): add clippit install --skills command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [3.8.0] - July 19, 2026
+
+- feat(cli): add `clippit install --skills` command to install bundled Clippit workspace skills for OpenCode, Pi, and Claude Code assistants
+- perf: convert static readonly `Dictionary` to `FrozenDictionary` in PowerPoint and Word (#434)
+- perf: convert static readonly `Dictionary` to `FrozenDictionary` in Word and Html (#435)
+- perf: convert static readonly `Dictionary` to `FrozenDictionary` in Excel, Html, and Word (#437)
+- perf(word): use `Dictionary` for O(1) image deduplication in `DocumentBuilder` (#428)
+- test(common): strengthen `MetricsGetter` tests with structural assertions (MG002-MG014) (#436)
+- test+refactor: `StringExtensions.SplitAndKeep` tests + `fr_FR` dead code removal (#430)
+- chore(deps): update SkiaSharp 4.148.0 → 4.150.0 (#429)
+- chore(deps): update SkiaSharp 4.150.0→4.150.1, TUnit 1.58.0→1.59.0, Test.Sdk 18.7.0→18.8.1 (#431)
+- chore(deps): bump actions/setup-node from 6 to 7 (#433)
+
 ## [3.7.0] - July 12, 2026
 
 - feat(cli): add `clippit word build init/run` command (#422)

--- a/Clippit.Cli/CHANGELOG.md
+++ b/Clippit.Cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.8.0] - 2026-07-19
+
+- Added `install --skills` command to install bundled Clippit workspace skills into
+  the current workspace. By default, `--skills` installs `.agents/skills/clippit`, a
+  shared project-local location supported by OpenCode and Pi. Use `--skills=claude`
+  for `.claude/skills/clippit`, or `--skills=all` to install both locations for
+  workspaces that use multiple assistants. Re-running the command replaces installed
+  skills with the current bundled versions; `--dry-run` prints the planned `SKILL.md`
+  paths without writing files.
+
 ## [0.7.0] - 2026-07-12
 
 - Added `excel create` command to generate an `.xlsx` workbook from a JSON workbook

--- a/Clippit.Cli/CliJsonContext.cs
+++ b/Clippit.Cli/CliJsonContext.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Clippit.Cli.Commands.Common.Verify;
 using Clippit.Cli.Commands.Excel.Create;
+using Clippit.Cli.Commands.Install;
 using Clippit.Cli.Commands.Pptx.Build;
 using Clippit.Cli.Commands.Pptx.Split;
 using Clippit.Cli.Commands.Pptx.Verify;
@@ -43,6 +44,9 @@ namespace Clippit.Cli;
 [JsonSerializable(typeof(WordBuildInitResult))]
 [JsonSerializable(typeof(WorkbookDefinition))]
 [JsonSerializable(typeof(CreateResult))]
+[JsonSerializable(typeof(InstallResult))]
+[JsonSerializable(typeof(InstalledSkillResult))]
+[JsonSerializable(typeof(InstallPlanResult))]
 [JsonSerializable(typeof(ErrorResult))]
 [JsonSourceGenerationOptions(
     WriteIndented = false,

--- a/Clippit.Cli/Clippit.Cli.csproj
+++ b/Clippit.Cli/Clippit.Cli.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <None Include="..\docs\images\logo.jpeg" Pack="true" PackagePath="\" />
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="Skills\clippit\**\*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Clippit.Cli/Commands/Install/InstallCommand.cs
+++ b/Clippit.Cli/Commands/Install/InstallCommand.cs
@@ -1,0 +1,60 @@
+using System.CommandLine;
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Install;
+
+internal static class InstallCommand
+{
+    public static Command Build()
+    {
+        var skillsOption = new Option<string?>("--skills")
+        {
+            Description = "Install Clippit agent skills into this workspace. Values: agents (default), claude, all.",
+            Arity = ArgumentArity.ZeroOrOne,
+        };
+
+        var dryRunOption = new Option<bool>("--dry-run")
+        {
+            Description = "Print the skill files that would be installed without writing them.",
+        };
+
+        var cmd = new Command(
+            "install",
+            "Install Clippit workspace integrations."
+                + "\n\nExamples:"
+                + "\n  clippit install --skills"
+                + "\n  clippit install --skills=agents"
+                + "\n  clippit install --skills=all"
+        );
+        cmd.Options.Add(skillsOption);
+        cmd.Options.Add(dryRunOption);
+        var (formatOption, quietOption) = cmd.AddOutputOptions();
+
+        cmd.SetAction(parseResult =>
+            CommandRunner.Execute(() =>
+            {
+                var skillsResult = parseResult.GetResult(skillsOption);
+                if (skillsResult is null)
+                    throw CliException.InvalidArguments(
+                        "Specify what to install, for example: clippit install --skills"
+                    );
+
+                var skillsTarget = parseResult.GetValue(skillsOption);
+                var writer = new OutputWriter(parseResult.GetValue(formatOption), parseResult.GetValue(quietOption));
+
+                if (parseResult.GetValue(dryRunOption))
+                {
+                    var plan = InstallSkillsService.Plan(skillsTarget);
+                    writer.WriteResult(plan, CliJsonContext.Default.InstallPlanResult, InstallPlanResult.WriteText);
+                    return ExitCodes.Success;
+                }
+
+                var result = InstallSkillsService.Install(skillsTarget);
+                writer.WriteResult(result, CliJsonContext.Default.InstallResult, InstallResult.WriteText);
+                return ExitCodes.Success;
+            })
+        );
+
+        return cmd;
+    }
+}

--- a/Clippit.Cli/Commands/Install/InstallCommand.cs
+++ b/Clippit.Cli/Commands/Install/InstallCommand.cs
@@ -24,6 +24,7 @@ internal static class InstallCommand
                 + "\n\nExamples:"
                 + "\n  clippit install --skills"
                 + "\n  clippit install --skills=agents"
+                + "\n  clippit install --skills=claude"
                 + "\n  clippit install --skills=all"
         );
         cmd.Options.Add(skillsOption);

--- a/Clippit.Cli/Commands/Install/InstallResult.cs
+++ b/Clippit.Cli/Commands/Install/InstallResult.cs
@@ -1,0 +1,43 @@
+namespace Clippit.Cli.Commands.Install;
+
+internal sealed class InstallResult
+{
+    public required IReadOnlyList<InstalledSkillResult> Installed { get; init; }
+    public required string Version { get; init; }
+
+    public static void WriteText(InstallResult result, TextWriter writer)
+    {
+        if (result.Installed.Count == 0)
+        {
+            writer.WriteLine("No Clippit skills installed.");
+            return;
+        }
+
+        writer.WriteLine(result.Installed.Count == 1 ? "Installed Clippit skill:" : "Installed Clippit skills:");
+        foreach (var installed in result.Installed)
+            writer.WriteLine($"  {installed.Path}");
+    }
+}
+
+internal sealed class InstalledSkillResult
+{
+    public required string Target { get; init; }
+    public required string Path { get; init; }
+}
+
+internal sealed class InstallPlanResult
+{
+    public required IReadOnlyList<string> Paths { get; init; }
+
+    public static void WriteText(InstallPlanResult result, TextWriter writer)
+    {
+        if (result.Paths.Count == 0)
+        {
+            writer.WriteLine("No Clippit skills planned.");
+            return;
+        }
+
+        foreach (var path in result.Paths)
+            writer.WriteLine(path);
+    }
+}

--- a/Clippit.Cli/Commands/Install/InstallSkillsService.cs
+++ b/Clippit.Cli/Commands/Install/InstallSkillsService.cs
@@ -21,6 +21,7 @@ internal static class InstallSkillsService
     public static InstallResult Install(string? targetValue)
     {
         var targets = ResolveTargets(targetValue);
+        var files = ReadBundledSkillFiles();
         var installed = new List<InstalledSkillResult>();
 
         foreach (var target in targets)
@@ -32,7 +33,7 @@ internal static class InstallSkillsService
                 targetDirectory.Delete(recursive: true);
 
             targetDirectory.Create();
-            WriteSkillFiles(targetDirectory, ReadBundledSkillFiles());
+            WriteSkillFiles(targetDirectory, files);
 
             installed.Add(
                 new InstalledSkillResult { Target = target, Path = RelativeToCurrentDirectory(skillFile.FullName) }

--- a/Clippit.Cli/Commands/Install/InstallSkillsService.cs
+++ b/Clippit.Cli/Commands/Install/InstallSkillsService.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using Clippit.Cli.Commands.Version;
+using Clippit.Cli.Infrastructure;
+
+namespace Clippit.Cli.Commands.Install;
+
+internal static class InstallSkillsService
+{
+    public const string DefaultTarget = "agents";
+
+    private static readonly string[] s_skillFiles =
+    [
+        "SKILL.md",
+        "references/workflows.md",
+        "references/manifests.md",
+        "references/output.md",
+    ];
+
+    private static readonly Assembly s_assembly = typeof(InstallSkillsService).Assembly;
+
+    public static InstallResult Install(string? targetValue)
+    {
+        var targets = ResolveTargets(targetValue);
+        var installed = new List<InstalledSkillResult>();
+
+        foreach (var target in targets)
+        {
+            var targetDirectory = ResolveTargetDirectory(target);
+            var skillFile = new FileInfo(Path.Combine(targetDirectory.FullName, "SKILL.md"));
+
+            if (targetDirectory.Exists)
+                targetDirectory.Delete(recursive: true);
+
+            targetDirectory.Create();
+            WriteSkillFiles(targetDirectory, ReadBundledSkillFiles());
+
+            installed.Add(
+                new InstalledSkillResult { Target = target, Path = RelativeToCurrentDirectory(skillFile.FullName) }
+            );
+        }
+
+        return new InstallResult { Installed = installed, Version = VersionCommand.GetCleanVersion() };
+    }
+
+    public static InstallPlanResult Plan(string? targetValue) =>
+        new()
+        {
+            Paths = ResolveTargets(targetValue)
+                .Select(target =>
+                    RelativeToCurrentDirectory(Path.Combine(ResolveTargetDirectory(target).FullName, "SKILL.md"))
+                )
+                .ToList(),
+        };
+
+    private static IReadOnlyList<string> ResolveTargets(string? targetValue)
+    {
+        var normalized = string.IsNullOrWhiteSpace(targetValue) ? "AGENTS" : targetValue.Trim().ToUpperInvariant();
+        return normalized switch
+        {
+            "CLAUDE" => ["claude"],
+            "AGENTS" => ["agents"],
+            "ALL" => ["agents", "claude"],
+            _ => throw CliException.InvalidArguments(
+                $"Invalid value for --skills: '{targetValue}'. Allowed values are: claude, agents, all."
+            ),
+        };
+    }
+
+    private static DirectoryInfo ResolveTargetDirectory(string target) =>
+        new(Path.Combine(Directory.GetCurrentDirectory(), $".{target}", "skills", "clippit"));
+
+    private static Dictionary<string, string> ReadBundledSkillFiles()
+    {
+        var files = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var relativePath in s_skillFiles)
+        {
+            var resourceName = FindResourceName(relativePath);
+            using var stream = s_assembly.GetManifestResourceStream(resourceName);
+            if (stream is null)
+            {
+                throw new FileNotFoundException($"Bundled Clippit skill resource could not be loaded: {resourceName}");
+            }
+
+            using var reader = new StreamReader(stream);
+            var content = reader.ReadToEnd();
+            files[relativePath] =
+                relativePath == "SKILL.md"
+                    ? content.Replace(
+                        "<!-- clippit-skill-version: bundled -->",
+                        $"<!-- clippit-skill-version: {VersionCommand.GetCleanVersion()} -->",
+                        StringComparison.Ordinal
+                    )
+                    : content;
+        }
+
+        return files;
+    }
+
+    private static string FindResourceName(string relativePath)
+    {
+        var suffix = relativePath.Replace('/', '.');
+        var resourceName = s_assembly
+            .GetManifestResourceNames()
+            .FirstOrDefault(name => name.EndsWith(suffix, StringComparison.Ordinal));
+
+        if (resourceName is null)
+        {
+            throw new FileNotFoundException(
+                $"Bundled Clippit skill resource was not found for '{relativePath}'. "
+                    + $"Available resources: {string.Join(", ", s_assembly.GetManifestResourceNames())}"
+            );
+        }
+
+        return resourceName;
+    }
+
+    private static void WriteSkillFiles(DirectoryInfo targetDirectory, Dictionary<string, string> files)
+    {
+        foreach (var (relativePath, content) in files)
+        {
+            var destination = new FileInfo(Path.Combine(targetDirectory.FullName, relativePath));
+            destination.Directory?.Create();
+            File.WriteAllText(destination.FullName, content);
+        }
+    }
+
+    private static string RelativeToCurrentDirectory(string path) =>
+        Path.GetRelativePath(Directory.GetCurrentDirectory(), path).Replace(Path.DirectorySeparatorChar, '/');
+}

--- a/Clippit.Cli/Program.cs
+++ b/Clippit.Cli/Program.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Text.Json;
 using Clippit.Cli;
 using Clippit.Cli.Commands.Excel;
+using Clippit.Cli.Commands.Install;
 using Clippit.Cli.Commands.Pptx;
 using Clippit.Cli.Commands.Version;
 using Clippit.Cli.Commands.Word;
@@ -11,6 +12,7 @@ var rootCommand = new RootCommand("Clippit — PowerTools CLI for OpenXml (Power
 rootCommand.Subcommands.Add(PptxCommand.Build());
 rootCommand.Subcommands.Add(WordCommand.Build());
 rootCommand.Subcommands.Add(ExcelCommand.Build());
+rootCommand.Subcommands.Add(InstallCommand.Build());
 rootCommand.Subcommands.Add(VersionCommand.Build());
 
 args = NormalizeHelpArgs(args);

--- a/Clippit.Cli/README.md
+++ b/Clippit.Cli/README.md
@@ -6,6 +6,29 @@
 
 ```bash
 dotnet tool install -g Clippit.Cli
+clippit --version
+```
+
+To update an existing global tool installation:
+
+```bash
+dotnet tool update -g Clippit.Cli
+```
+
+## Workspace skills
+
+Install local workspace skills for compatible coding assistants:
+
+```bash
+clippit install --skills          # .agents/skills/clippit
+clippit install --skills=claude   # .claude/skills/clippit
+clippit install --skills=all      # both targets
+```
+
+The default writes the shared `.agents` project-local skill location used by OpenCode and Pi. Use `--skills=claude` for Claude Code or `--skills=all` for workspaces that use multiple assistants. Re-running the command replaces installed skills with the current bundled versions. Use `--dry-run` to preview target paths.
+
+```bash
+clippit install --skills=all --dry-run
 ```
 
 ## Quick Start
@@ -79,6 +102,7 @@ clippit pptx split presentation.pptx --format json
 | `excel to-html` | Convert an XLSX sheet, range, or table to HTML/CSS. |
 | `excel create` | Generate an `.xlsx` workbook from a JSON workbook definition. |
 | `excel verify` | Validate an XLSX — schema and relationships. |
+| `install --skills` | Install Clippit workspace skills into the current workspace. |
 | `version` | Print version information. |
 
 ### Common flags

--- a/Clippit.Cli/Skills/clippit/SKILL.md
+++ b/Clippit.Cli/Skills/clippit/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: clippit
+description: Work with OpenXml PowerPoint, Word, and Excel files using Clippit CLI: split/build/verify PPTX, build/compare/assemble DOCX, convert DOCX/XLSX to HTML, and create XLSX.
+allowed-tools: Bash(clippit:*) Bash(dotnet:*)
+---
+<!-- clippit-skill-version: bundled -->
+
+# Clippit CLI
+
+Use `clippit` for deterministic OpenXml document operations. Prefer it over manual zip/XML edits for `.pptx`, `.docx`, and `.xlsx` files.
+
+## Discover commands
+
+```bash
+clippit --help
+clippit pptx --help
+clippit word --help
+clippit excel --help
+```
+
+Run command-specific help before using unfamiliar options:
+
+```bash
+clippit pptx split --help
+clippit word simplify-markup --help
+```
+
+## Automation rules
+
+- Validate generated Office files with the matching `verify` command.
+- Use `--format json` when another step needs machine-readable output.
+- Do not overwrite user documents unless explicitly requested; write a new output file.
+- Prefer manifest scaffolding commands over hand-authoring manifests from scratch.
+- Success payloads are stdout. Command errors are stderr JSON with a stable `code`.
+- For full options, trust `clippit <command> --help`; this skill is a compact runbook, not the full docs.
+
+## Validate files
+
+```bash
+clippit pptx verify deck.pptx --format json
+clippit word verify document.docx --format json
+clippit excel verify workbook.xlsx --format json
+```
+
+If validation fails, inspect stderr/stdout JSON and report the diagnostics instead of assuming the file is usable.
+
+## PowerPoint workflows
+
+Split a deck:
+
+```bash
+clippit pptx split deck.pptx --output slides --manifest
+```
+
+Extract selected slides:
+
+```bash
+clippit pptx split deck.pptx --slides 1,3,6-9 --output slides
+```
+
+Build a deck from a manifest:
+
+```bash
+clippit pptx build init --output deck-manifest.json
+clippit pptx build run deck-manifest.json --output rebuilt.pptx
+clippit pptx verify rebuilt.pptx --format json
+```
+
+## Word workflows
+
+Build/merge documents:
+
+```bash
+clippit word build init --output word-build.json
+clippit word build run word-build.json --output merged.docx
+clippit word verify merged.docx --format json
+```
+
+Compare or consolidate revisions:
+
+```bash
+clippit word compare before.docx after.docx --output compared.docx
+clippit word consolidate original.docx alice.docx bob.docx --output consolidated.docx
+```
+
+Assemble a template with XML data:
+
+```bash
+clippit word assemble template.docx data.xml --output assembled.docx
+clippit word verify assembled.docx --format json
+```
+
+Clean markup safely:
+
+```bash
+clippit word accept-revisions draft.docx --output accepted.docx
+clippit word simplify-markup document.docx --accept-revisions --remove-comments --output simplified.docx
+```
+
+Convert Word and HTML:
+
+```bash
+clippit word to-html document.docx --output document.html
+clippit word from-html article.html --output article.docx
+```
+
+## Excel workflows
+
+```bash
+clippit excel verify workbook.xlsx --format json
+clippit excel to-html workbook.xlsx --sheet "Sheet1" --output sheet.html
+clippit excel create workbook.json --output workbook.xlsx
+clippit excel verify workbook.xlsx --format json
+```
+
+## More details
+
+Read these only when needed:
+
+- `references/workflows.md` for multi-step PPTX, DOCX, and XLSX recipes.
+- `references/manifests.md` for minimal manifest examples and schema guidance.
+- `references/output.md` for JSON output, exit codes, and scripting patterns.

--- a/Clippit.Cli/Skills/clippit/SKILL.md
+++ b/Clippit.Cli/Skills/clippit/SKILL.md
@@ -1,122 +1,57 @@
 ---
 name: clippit
-description: Work with OpenXml PowerPoint, Word, and Excel files using Clippit CLI: split/build/verify PPTX, build/compare/assemble DOCX, convert DOCX/XLSX to HTML, and create XLSX.
-allowed-tools: Bash(clippit:*) Bash(dotnet:*)
+description: PPTX automation with Clippit CLI (split, build, verify). Also supports DOCX and XLSX workflows via references.
+allowed-tools: Bash(clippit:*)
 ---
 <!-- clippit-skill-version: bundled -->
 
 # Clippit CLI
 
-Use `clippit` for deterministic OpenXml document operations. Prefer it over manual zip/XML edits for `.pptx`, `.docx`, and `.xlsx` files.
+Use `clippit` for deterministic OpenXml operations. Prefer it over manual zip/XML edits for `.pptx`, `.docx`, and `.xlsx`.
 
-## Discover commands
+## PowerPoint (primary)
 
-```bash
-clippit --help
-clippit pptx --help
-clippit word --help
-clippit excel --help
-```
-
-Run command-specific help before using unfamiliar options:
-
-```bash
-clippit pptx split --help
-clippit word simplify-markup --help
-```
-
-## Automation rules
-
-- Validate generated Office files with the matching `verify` command.
-- Use `--format json` when another step needs machine-readable output.
-- Do not overwrite user documents unless explicitly requested; write a new output file.
-- Prefer manifest scaffolding commands over hand-authoring manifests from scratch.
-- Success payloads are stdout. Command errors are stderr JSON with a stable `code`.
-- For full options, trust `clippit <command> --help`; this skill is a compact runbook, not the full docs.
-
-## Validate files
-
-```bash
-clippit pptx verify deck.pptx --format json
-clippit word verify document.docx --format json
-clippit excel verify workbook.xlsx --format json
-```
-
-If validation fails, inspect stderr/stdout JSON and report the diagnostics instead of assuming the file is usable.
-
-## PowerPoint workflows
-
-Split a deck:
+Split a deck into single-slide files with a manifest:
 
 ```bash
 clippit pptx split deck.pptx --output slides --manifest
 ```
 
-Extract selected slides:
+Extract a subset of slides:
 
 ```bash
-clippit pptx split deck.pptx --slides 1,3,6-9 --output slides
+clippit pptx split deck.pptx --slides 1,3,6-9 --output subset
 ```
 
 Build a deck from a manifest:
 
 ```bash
-clippit pptx build init --output deck-manifest.json
-clippit pptx build run deck-manifest.json --output rebuilt.pptx
-clippit pptx verify rebuilt.pptx --format json
+clippit pptx build init --output deck.json
+clippit pptx build run deck.json --output built.pptx
+clippit pptx verify built.pptx --format json
 ```
 
-## Word workflows
-
-Build/merge documents:
+Verify any PPTX:
 
 ```bash
-clippit word build init --output word-build.json
-clippit word build run word-build.json --output merged.docx
-clippit word verify merged.docx --format json
+clippit pptx verify deck.pptx --format json
 ```
 
-Compare or consolidate revisions:
+## Other formats
 
-```bash
-clippit word compare before.docx after.docx --output compared.docx
-clippit word consolidate original.docx alice.docx bob.docx --output consolidated.docx
-```
+For DOCX (build, compare, assemble, HTML conversion) and XLSX (create, to-html), see `references/workflows.md`.
 
-Assemble a template with XML data:
+## Rules
 
-```bash
-clippit word assemble template.docx data.xml --output assembled.docx
-clippit word verify assembled.docx --format json
-```
+- Run `clippit pptx <command> --help` for full options.
+- Use `--format json` for machine-readable output.
+- Prefer manifest scaffolding (`pptx build init`) over hand-authoring manifests.
+- Validate generated files with the matching `verify` command.
+- Success payloads go to stdout; errors are stderr JSON with a stable `code`.
+- Do not overwrite user documents unless explicitly requested.
 
-Clean markup safely:
+## References
 
-```bash
-clippit word accept-revisions draft.docx --output accepted.docx
-clippit word simplify-markup document.docx --accept-revisions --remove-comments --output simplified.docx
-```
-
-Convert Word and HTML:
-
-```bash
-clippit word to-html document.docx --output document.html
-clippit word from-html article.html --output article.docx
-```
-
-## Excel workflows
-
-```bash
-clippit excel verify workbook.xlsx --format json
-clippit excel to-html workbook.xlsx --sheet "Sheet1" --output sheet.html
-clippit excel create workbook.json --output workbook.xlsx
-clippit excel verify workbook.xlsx --format json
-```
-
-## More details
-
-Read these only when needed:
-
-- `references/workflows.md` for multi-step PPTX, DOCX, and XLSX recipes.
-- `references/manifests.md` for minimal manifest examples and schema guidance.
-- `references/output.md` for JSON output, exit codes, and scripting patterns.
+- `references/workflows.md` — multi-step recipes for PPTX, DOCX, XLSX.
+- `references/manifests.md` — manifest examples and schema guidance.
+- `references/output.md` — JSON contracts, exit codes, scripting patterns.

--- a/Clippit.Cli/Skills/clippit/references/manifests.md
+++ b/Clippit.Cli/Skills/clippit/references/manifests.md
@@ -1,0 +1,80 @@
+# Clippit manifest guidance
+
+Prefer scaffolding manifests and editing the generated JSON rather than inventing the shape from memory.
+
+```bash
+clippit pptx build init --output deck.json
+clippit word build init --output word-build.json
+```
+
+For authoritative contracts, use the published schemas in `docs/schemas/` or the repository documentation. This file only gives minimal examples.
+
+## PPTX deck manifest
+
+Typical flow:
+
+```bash
+clippit pptx build init --output deck.json
+clippit pptx build run deck.json --output built.pptx
+```
+
+Minimal shape:
+
+```json
+{
+  "$schema": "https://sergey-tihon.github.io/Clippit/schemas/deck-manifest.v1.json",
+  "title": "Combined deck",
+  "output": "combined.pptx",
+  "deck": [
+    "[Intro]",
+    "slides/title.pptx",
+    "slides/agenda.pptx",
+    "[Appendix]",
+    "appendix.pptx"
+  ]
+}
+```
+
+Section markers are strings in square brackets. Paths should be kept relative to the manifest when possible.
+
+## Word build manifest
+
+Typical flow:
+
+```bash
+clippit word build init --output word-build.json
+clippit word build run word-build.json --output merged.docx
+```
+
+Minimal shape:
+
+```json
+{
+  "$schema": "https://sergey-tihon.github.io/Clippit/schemas/word-build-manifest.v1.json",
+  "output": "merged.docx",
+  "entries": [
+    "cover.docx",
+    "[Chapter 1]",
+    "chapter-1.docx",
+    "[Chapter 2]",
+    "chapter-2.docx"
+  ]
+}
+```
+
+## Excel workbook definition
+
+Use with:
+
+```bash
+clippit excel create workbook.json --output workbook.xlsx
+```
+
+Minimal shape varies with workbook features. Check `docs/schemas/workbook-definition.v1.json` and prefer existing examples when available.
+
+## Rules
+
+- Do not embed full schemas in prompts or generated answers; point to schema files.
+- Preserve `$schema` when editing manifests.
+- Keep paths portable and relative unless the user asks for absolute paths.
+- After generating Office output from a manifest, run the matching `verify` command.

--- a/Clippit.Cli/Skills/clippit/references/output.md
+++ b/Clippit.Cli/Skills/clippit/references/output.md
@@ -1,0 +1,51 @@
+# Clippit CLI output contract
+
+Use this when scripting or when another tool must consume results.
+
+## Streams
+
+- Successful command payloads are written to stdout.
+- Command execution errors are written to stderr as compact JSON with `error` and `code`.
+- Parser/help errors are produced by System.CommandLine and may include usage text.
+
+## Formats
+
+Use JSON for automation:
+
+```bash
+clippit pptx verify deck.pptx --format json
+clippit word compare before.docx after.docx --output compared.docx --format json
+```
+
+Use `--quiet` when only the exit code matters:
+
+```bash
+clippit word verify document.docx --quiet
+```
+
+Do not parse human text output. Re-run with `--format json` instead.
+
+## Exit code categories
+
+- `0`: success
+- `1`: internal error
+- `2`: invalid arguments
+- `3`: file not found
+- `4`: invalid Office/OpenXml/JSON format
+- `5`: output/write error
+
+For validation commands, an invalid-but-readable Office file can return diagnostics and a non-zero exit code. Report diagnostics to the user.
+
+## Safe automation pattern
+
+```bash
+if clippit pptx verify deck.pptx --format json >verify.json 2>error.json; then
+  echo "valid"
+else
+  echo "invalid or failed; inspect verify.json and error.json"
+fi
+```
+
+## Binary piping
+
+Some commands support `-` for stdin or stdout. Only use binary stdout when explicitly needed, and avoid mixing text summaries with binary streams. Prefer file outputs for agent workflows.

--- a/Clippit.Cli/Skills/clippit/references/workflows.md
+++ b/Clippit.Cli/Skills/clippit/references/workflows.md
@@ -1,0 +1,103 @@
+# Clippit workflow recipes
+
+Use these recipes when a user asks for a document transformation. Write outputs to new paths unless the user explicitly asks to overwrite.
+
+## PPTX: split, edit manifest, rebuild
+
+```bash
+clippit pptx split source.pptx --output slides --manifest
+# edit generated slides/source.manifest.json if needed
+clippit pptx build run slides/source.manifest.json --output rebuilt.pptx
+clippit pptx verify rebuilt.pptx --format json
+```
+
+Use `--slides` for subsets:
+
+```bash
+clippit pptx split source.pptx --slides 1,3,6-9 --output subset
+```
+
+## PPTX: scaffold a deck manifest
+
+```bash
+clippit pptx build init --output deck.json
+# edit deck.json to list source decks, slide files, and section markers
+clippit pptx build run deck.json --output deck.pptx
+clippit pptx verify deck.pptx --format json
+```
+
+## DOCX: merge documents
+
+```bash
+clippit word build init --output word-build.json
+# edit word-build.json to list source documents
+clippit word build run word-build.json --output merged.docx
+clippit word verify merged.docx --format json
+```
+
+## DOCX: compare two versions
+
+Use when the user wants tracked revisions between two files.
+
+```bash
+clippit word compare before.docx after.docx --output compared.docx
+clippit word verify compared.docx --format json
+```
+
+## DOCX: consolidate reviewer files
+
+Use when there is one original and multiple independently edited copies.
+
+```bash
+clippit word consolidate original.docx reviewer-a.docx reviewer-b.docx --output consolidated.docx
+clippit word verify consolidated.docx --format json
+```
+
+## DOCX: template assembly
+
+Use when a `.docx` template contains DocumentAssembler markup and data is XML.
+
+```bash
+clippit word assemble template.docx data.xml --output assembled.docx
+clippit word verify assembled.docx --format json
+```
+
+## DOCX: cleanup
+
+Accept revisions only:
+
+```bash
+clippit word accept-revisions draft.docx --output accepted.docx
+```
+
+Remove selected non-content markup:
+
+```bash
+clippit word simplify-markup document.docx --accept-revisions --remove-comments --output simplified.docx
+clippit word verify simplified.docx --format json
+```
+
+Check `clippit word simplify-markup --help` before using broad cleanup presets such as `--all`.
+
+## HTML conversions
+
+```bash
+clippit word to-html document.docx --output document.html
+clippit word from-html article.html --css styles.css --output article.docx
+clippit word verify article.docx --format json
+```
+
+## XLSX: create from JSON
+
+```bash
+clippit excel create workbook.json --output report.xlsx
+clippit excel verify report.xlsx --format json
+```
+
+## XLSX: export a sheet/range/table to HTML
+
+```bash
+clippit excel to-html workbook.xlsx --sheet "Sheet1" --output sheet.html
+clippit excel to-html workbook.xlsx --sheet "Sheet1" --range "A1:D20" --output range.html
+clippit excel to-html workbook.xlsx --table "SalesTable" --output table.html
+```

--- a/Clippit.Tests/Cli/CliJsonContractTests.cs
+++ b/Clippit.Tests/Cli/CliJsonContractTests.cs
@@ -299,6 +299,38 @@ internal sealed class CliJsonContractTests : TestsBase
     }
 
     [Test]
+    public async Task CLI199_InstallSkills_JsonResult_MatchesSchema()
+    {
+        var directory = CliTestRunner.CreateTempDirectory("contract-install-result");
+
+        var result = await CliTestRunner
+            .RunManagedAsync(directory, "install", "--skills=all", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var payload = result.ReadStdoutJson();
+        ValidateJsonAgainstSchema(payload.RootElement, "install-result.v1.json");
+    }
+
+    [Test]
+    public async Task CLI200_InstallSkillsDryRun_JsonPlan_MatchesSchema()
+    {
+        var directory = CliTestRunner.CreateTempDirectory("contract-install-plan");
+
+        var result = await CliTestRunner
+            .RunManagedAsync(directory, "install", "--skills=all", "--dry-run", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var payload = result.ReadStdoutJson();
+        ValidateJsonAgainstSchema(payload.RootElement, "install-plan.v1.json");
+    }
+
+    [Test]
     public async Task CLI104_JsonSchema_RejectsInvalidPayloads()
     {
         using var negativeCount = JsonDocument.Parse(

--- a/Clippit.Tests/Cli/CliJsonContractTests.cs
+++ b/Clippit.Tests/Cli/CliJsonContractTests.cs
@@ -299,7 +299,7 @@ internal sealed class CliJsonContractTests : TestsBase
     }
 
     [Test]
-    public async Task CLI199_InstallSkills_JsonResult_MatchesSchema()
+    public async Task CLI201_InstallSkills_JsonResult_MatchesSchema()
     {
         var directory = CliTestRunner.CreateTempDirectory("contract-install-result");
 
@@ -315,7 +315,7 @@ internal sealed class CliJsonContractTests : TestsBase
     }
 
     [Test]
-    public async Task CLI200_InstallSkillsDryRun_JsonPlan_MatchesSchema()
+    public async Task CLI202_InstallSkillsDryRun_JsonPlan_MatchesSchema()
     {
         var directory = CliTestRunner.CreateTempDirectory("contract-install-plan");
 

--- a/Clippit.Tests/Cli/CliTestRunner.cs
+++ b/Clippit.Tests/Cli/CliTestRunner.cs
@@ -38,6 +38,13 @@ internal static class CliTestRunner
         RunAsync("dotnet", [GetManagedCliDll().FullName, .. arguments], RepositoryRoot.FullName, s_defaultTimeout);
 
     /// <summary>
+    /// Runs the managed CLI in <paramref name="workingDirectory"/> instead of the repository root. Use for
+    /// commands whose behavior depends on the current directory (e.g. <c>install --skills</c>).
+    /// </summary>
+    public static Task<CliResult> RunManagedAsync(DirectoryInfo workingDirectory, params string[] arguments) =>
+        RunAsync("dotnet", [GetManagedCliDll().FullName, .. arguments], workingDirectory.FullName, s_defaultTimeout);
+
+    /// <summary>
     /// Runs the managed CLI with content piped into stdin. Returned stdout is
     /// captured as raw bytes so callers can verify binary <c>--output -</c>
     /// pipelines (e.g. <c>pptx build run - --output -</c>).
@@ -127,7 +134,7 @@ internal static class CliTestRunner
         return new CliResult(process.ExitCode, stdout, stderr);
     }
 
-    private static FileInfo GetManagedCliDll()
+    public static FileInfo GetManagedCliDll()
     {
         var testOutputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar));
         var targetFramework = testOutputDirectory.Name;

--- a/Clippit.Tests/Cli/Integration/InstallTests.cs
+++ b/Clippit.Tests/Cli/Integration/InstallTests.cs
@@ -1,0 +1,136 @@
+namespace Clippit.Tests.Cli.Integration;
+
+#pragma warning disable CA1707 // Test names follow the repository's prefix_code_descriptive_name convention.
+internal sealed class InstallTests : CliIntegrationTestBase
+{
+    [Test]
+    public async Task CLI194_InstallSkills_InstallsAgentsSkillByDefault()
+    {
+        var directory = CliTestRunner.CreateTempDirectory(nameof(CLI194_InstallSkills_InstallsAgentsSkillByDefault));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(directory, "install", "--skills", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert
+            .That(File.Exists(Path.Combine(directory.FullName, ".agents", "skills", "clippit", "SKILL.md")))
+            .IsTrue();
+        await Assert
+            .That(
+                File.Exists(
+                    Path.Combine(directory.FullName, ".agents", "skills", "clippit", "references", "workflows.md")
+                )
+            )
+            .IsTrue();
+        await Assert.That(Directory.Exists(Path.Combine(directory.FullName, ".claude"))).IsFalse();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("installed").GetArrayLength()).IsEqualTo(1);
+        var installed = json.RootElement.GetProperty("installed")[0];
+        await Assert.That(installed.GetProperty("target").GetString()).IsEqualTo("agents");
+        await Assert.That(installed.GetProperty("path").GetString()).IsEqualTo(".agents/skills/clippit/SKILL.md");
+        await Assert.That(json.RootElement.GetProperty("version").GetString()).IsNotNull();
+    }
+
+    [Test]
+    public async Task CLI195_InstallSkillsAgents_InstallsAgentsSkill()
+    {
+        var directory = CliTestRunner.CreateTempDirectory(nameof(CLI195_InstallSkillsAgents_InstallsAgentsSkill));
+
+        var result = await CliTestRunner.RunManagedAsync(directory, "install", "--skills=agents").ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert
+            .That(File.Exists(Path.Combine(directory.FullName, ".agents", "skills", "clippit", "SKILL.md")))
+            .IsTrue();
+        await Assert.That(result.StandardOutput).Contains(".agents/skills/clippit/SKILL.md");
+    }
+
+    [Test]
+    public async Task CLI196_InstallSkillsAll_InstallsBothTargets()
+    {
+        var directory = CliTestRunner.CreateTempDirectory(nameof(CLI196_InstallSkillsAll_InstallsBothTargets));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(directory, "install", "--skills=all", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+        await Assert
+            .That(File.Exists(Path.Combine(directory.FullName, ".claude", "skills", "clippit", "SKILL.md")))
+            .IsTrue();
+        await Assert
+            .That(File.Exists(Path.Combine(directory.FullName, ".agents", "skills", "clippit", "SKILL.md")))
+            .IsTrue();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("installed").GetArrayLength()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task CLI197_InstallSkills_IsIdempotent()
+    {
+        var directory = CliTestRunner.CreateTempDirectory(nameof(CLI197_InstallSkills_IsIdempotent));
+
+        var first = await CliTestRunner.RunManagedAsync(directory, "install", "--skills").ConfigureAwait(false);
+        var second = await CliTestRunner.RunManagedAsync(directory, "install", "--skills").ConfigureAwait(false);
+
+        await Assert.That(first.ExitCode).IsEqualTo(0);
+        await Assert.That(second.ExitCode).IsEqualTo(0);
+        await Assert.That(second.StandardError).IsEmpty();
+        await Assert
+            .That(File.Exists(Path.Combine(directory.FullName, ".agents", "skills", "clippit", "SKILL.md")))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task CLI198_InstallSkillsDryRun_DoesNotWriteFiles()
+    {
+        var directory = CliTestRunner.CreateTempDirectory(nameof(CLI198_InstallSkillsDryRun_DoesNotWriteFiles));
+
+        var result = await CliTestRunner
+            .RunManagedAsync(directory, "install", "--skills=all", "--dry-run", "--format", "json")
+            .ConfigureAwait(false);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.StandardError).IsEmpty();
+
+        using var json = result.ReadStdoutJson();
+        await Assert.That(json.RootElement.GetProperty("paths").GetArrayLength()).IsEqualTo(2);
+        var paths = json.RootElement.GetProperty("paths").EnumerateArray().Select(path => path.GetString()).ToList();
+        await Assert.That(paths).Contains(".agents/skills/clippit/SKILL.md");
+        await Assert.That(paths).Contains(".claude/skills/clippit/SKILL.md");
+        await Assert.That(Directory.Exists(Path.Combine(directory.FullName, ".claude"))).IsFalse();
+        await Assert.That(Directory.Exists(Path.Combine(directory.FullName, ".agents"))).IsFalse();
+    }
+
+    [Test]
+    public async Task CLI199_InstallSkills_OverwritesModifiedFilesAndRemovesExtraFiles()
+    {
+        var directory = CliTestRunner.CreateTempDirectory(
+            nameof(CLI199_InstallSkills_OverwritesModifiedFilesAndRemovesExtraFiles)
+        );
+
+        var first = await CliTestRunner.RunManagedAsync(directory, "install", "--skills").ConfigureAwait(false);
+        await Assert.That(first.ExitCode).IsEqualTo(0);
+
+        var skillPath = Path.Combine(directory.FullName, ".agents", "skills", "clippit", "SKILL.md");
+        await File.WriteAllTextAsync(skillPath, "modified skill content").ConfigureAwait(false);
+
+        var extraPath = Path.Combine(directory.FullName, ".agents", "skills", "clippit", "references", "legacy.md");
+        await File.WriteAllTextAsync(extraPath, "old reference").ConfigureAwait(false);
+
+        var second = await CliTestRunner.RunManagedAsync(directory, "install", "--skills").ConfigureAwait(false);
+        await Assert.That(second.ExitCode).IsEqualTo(0);
+
+        var content = await File.ReadAllTextAsync(skillPath).ConfigureAwait(false);
+        await Assert.That(content).DoesNotContain("modified skill content");
+        await Assert.That(content).Contains("<!-- clippit-skill-version:");
+        await Assert.That(File.Exists(extraPath)).IsFalse();
+    }
+}
+#pragma warning restore CA1707

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ workflows.
 
 🛠️ **[CLI usage →](https://sergey-tihon.github.io/Clippit/cli.html)**
 
+🤖 **Workspace skills for coding assistants:** `clippit install --skills`
+
 ## Installation
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # Clippit CLI
 
-Clippit CLI is a scriptable command-line interface for PowerPoint (`pptx`), Word (`word`), and Excel (`excel`) document workflows. This documentation is split into focused pages so humans and LLM agents can load only the command set they need.
+Clippit CLI is a scriptable command-line interface for PowerPoint (`pptx`), Word (`word`), and Excel (`excel`) document workflows. This documentation is split into focused pages by command area.
 
 ## CLI pages
 
@@ -38,13 +38,36 @@ npm install -g clippit@latest
 npm uninstall -g clippit
 ```
 
+## Workspace skills
+
+Clippit can install local Agent Skills files for coding assistants that support
+workspace skills.
+
+Run the installer from the workspace where you want the skill files to live:
+
+```bash
+clippit install --skills          # installs .agents/skills/clippit
+clippit install --skills=claude   # installs .claude/skills/clippit
+clippit install --skills=all      # installs both targets
+```
+
+Running the command again replaces the installed skill files with the current
+bundled versions. Use `--dry-run` to preview the paths that would be written.
+
+```bash
+clippit install --skills=all --dry-run
+```
+
+For full command options and payload contracts, use these docs,
+`clippit <command> --help`, and the schemas listed below.
+
 ## Supported platforms
 
 - **Continuously tested:** Windows, Linux
 - **Runtime requirement:** .NET 10 runtime/toolchain for the `dotnet tool`; the npm package bundles native binaries for supported platforms
 - **Package managers:** `dotnet tool` (NuGet) and `npm`
 
-## Output contract (human + agent friendly)
+## Output contract
 
 Use `--format json` for automation. Text output is for interactive usage.
 
@@ -84,6 +107,36 @@ cat article.html | clippit word from-html - --output - > article.docx
 cat spreadsheet.xlsx | clippit excel verify - --format json
 ```
 
+## `install --skills`
+
+Installs bundled Clippit workspace skills.
+
+```text
+clippit install --skills[=agents|claude|all] [--dry-run] [--format json|text] [--quiet]
+```
+
+Targets:
+
+| Target | Install path |
+| --- | --- |
+| `agents` (default) | `.agents/skills/clippit/SKILL.md` |
+| `claude` | `.claude/skills/clippit/SKILL.md` |
+| `all` | both target directories |
+
+Text output lists installed skill paths. JSON output reports the installed targets,
+paths, and CLI version:
+
+```json
+{"installed":[{"target":"agents","path":".agents/skills/clippit/SKILL.md"}],"version":"0.8.0"}
+```
+
+`--dry-run` prints the planned `SKILL.md` paths instead of writing files. In JSON
+mode it returns:
+
+```json
+{"paths":[".agents/skills/clippit/SKILL.md"]}
+```
+
 ## `version`
 
 Prints Clippit CLI and Open XML SDK versions.
@@ -114,4 +167,6 @@ Schemas for manifests/results are in [schemas/README.md](schemas/README.md).
 | `word compare` result | `https://sergey-tihon.github.io/Clippit/schemas/compare-result.v1.json` |
 | `word consolidate` result | `https://sergey-tihon.github.io/Clippit/schemas/consolidate-result.v1.json` |
 | `excel create` result | `https://sergey-tihon.github.io/Clippit/schemas/excel-create-result.v1.json` |
+| `install --skills` result | `https://sergey-tihon.github.io/Clippit/schemas/install-result.v1.json` |
+| `install --skills --dry-run` plan | `https://sergey-tihon.github.io/Clippit/schemas/install-plan.v1.json` |
 | `word to-html`, `word from-html`, `word accept-revisions`, `word simplify-markup`, `excel to-html` result | `https://sergey-tihon.github.io/Clippit/schemas/convert-result.v1.json` |

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -21,6 +21,8 @@ published for documentation, integration validation, and contract tests.
 | [`assemble-result.v1.json`](./assemble-result.v1.json) | Stdout payload of `clippit word assemble` (JSON mode)                                                                                                                       |
 | [`consolidate-result.v1.json`](./consolidate-result.v1.json) | Stdout payload of `clippit word consolidate` (JSON mode)                                                                                                            |
 | [`excel-create-result.v1.json`](./excel-create-result.v1.json) | Stdout payload of `clippit excel create` (JSON mode)                                                                                                              |
+| [`install-result.v1.json`](./install-result.v1.json)   | Stdout payload of `clippit install --skills` (JSON mode)                                                                                                           |
+| [`install-plan.v1.json`](./install-plan.v1.json)       | Stdout payload of `clippit install --skills --dry-run` (JSON mode)                                                                                                 |
 | [`convert-result.v1.json`](./convert-result.v1.json)   | Stdout payload of `clippit word to-html`, `clippit word from-html`, `clippit word accept-revisions`, `clippit word simplify-markup`, or `clippit excel to-html` (JSON mode) |
 
 ## Output discipline

--- a/docs/schemas/install-plan.v1.json
+++ b/docs/schemas/install-plan.v1.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sergey-tihon.github.io/Clippit/schemas/install-plan.v1.json",
+  "title": "InstallPlanResult",
+  "description": "Stdout payload of `clippit install --skills --dry-run` (JSON mode).",
+  "type": "object",
+  "required": ["paths"],
+  "additionalProperties": false,
+  "properties": {
+    "paths": {
+      "type": "array",
+      "description": "Workspace-relative paths to the SKILL.md files that would be installed.",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/schemas/install-result.v1.json
+++ b/docs/schemas/install-result.v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sergey-tihon.github.io/Clippit/schemas/install-result.v1.json",
+  "title": "InstallResult",
+  "description": "Stdout payload of `clippit install --skills` (JSON mode).",
+  "type": "object",
+  "required": ["installed", "version"],
+  "additionalProperties": false,
+  "properties": {
+    "installed": {
+      "type": "array",
+      "description": "Skill targets installed by the command.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["target", "path"],
+        "additionalProperties": false,
+        "properties": {
+          "target": {
+            "type": "string",
+            "description": "Installed skill target.",
+            "enum": ["claude", "agents"]
+          },
+          "path": {
+            "type": "string",
+            "description": "Workspace-relative path to the installed SKILL.md file."
+          }
+        }
+      }
+    },
+    "version": {
+      "type": "string",
+      "description": "Clippit CLI version used to stamp the installed skill."
+    }
+  }
+}

--- a/npm/clippit/README.md
+++ b/npm/clippit/README.md
@@ -8,6 +8,13 @@ This npm package provides native binaries for all platforms — no .NET runtime 
 
 ```bash
 npm install -g clippit
+clippit --version
+```
+
+To update an existing global npm installation:
+
+```bash
+npm install -g clippit@latest
 ```
 
 ## Quick Start
@@ -60,28 +67,44 @@ clippit excel create workbook.json --output report.xlsx
 clippit pptx split presentation.pptx --format json
 ```
 
+## Workspace skills
+
+Clippit can install local workspace skills for compatible coding assistants.
+
+```bash
+clippit install --skills          # .agents/skills/clippit
+clippit install --skills=claude   # .claude/skills/clippit
+clippit install --skills=all      # both targets
+```
+
+The default writes the shared `.agents` project-local skill location used by OpenCode
+and Pi. Use `--skills=claude` for Claude Code or `--skills=all` for workspaces that
+use multiple assistants. Re-running the command replaces installed skills with the
+current bundled versions. Use `--dry-run` to preview paths.
+
 ## Commands
 
-| Command           | Description                                                                                                                             |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `pptx split`      | Split a `.pptx` into individual single-slide files. Supports slide range selection (`--slides`) and manifest generation (`--manifest`). |
-| `pptx build init` | Scaffold a deck manifest (JSON).                                                                                                        |
-| `pptx build run`  | Assemble a `.pptx` from a deck manifest.                                                                                                |
-| `word build init` | Scaffold a Word build manifest (JSON).                                                                                                  |
-| `word build run`  | Assemble a `.docx` from a Word build manifest.                                                                                          |
-| `pptx verify`           | Validate a PPTX — schema, relationships, markup compatibility, and sections.                                                            |
-| `word assemble`         | Assemble a DOCX template with XML data.                                                                                                  |
-| `word compare`          | Compare two DOCX files and produce a tracked-revision DOCX.                                                                             |
-| `word consolidate`      | Combine multiple DOCX revisions into one tracked-changes DOCX.                                                                          |
-| `word accept-revisions` | Accept all tracked revisions in a DOCX file.                                                                                            |
-| `word simplify-markup`  | Remove non-content markup from a DOCX file.                                                                                             |
-| `word verify`           | Validate a DOCX — schema and relationships.                                                                                             |
-| `word to-html`    | Convert a DOCX to HTML/CSS.                                                                                                             |
-| `word from-html`  | Convert HTML/CSS to a DOCX.                                                                                                             |
-| `excel to-html`   | Convert an XLSX sheet, range, or table to HTML/CSS.                                                                                     |
-| `excel create`    | Generate an `.xlsx` workbook from a JSON workbook definition.                                                                           |
-| `excel verify`    | Validate an XLSX — schema and relationships.                                                                                            |
-| `version`         | Print version information.                                                                                                              |
+| Command | Description |
+| --- | --- |
+| `pptx split` | Split a `.pptx` into individual single-slide files. Supports slide range selection (`--slides`) and manifest generation (`--manifest`). |
+| `pptx build init` | Scaffold a deck manifest (JSON). |
+| `pptx build run` | Assemble a `.pptx` from a deck manifest. |
+| `pptx verify` | Validate a PPTX — schema, relationships, markup compatibility, and sections. |
+| `word build init` | Scaffold a Word build manifest (JSON). |
+| `word build run` | Assemble a `.docx` from a Word build manifest. |
+| `word assemble` | Assemble a DOCX template with XML data. |
+| `word compare` | Compare two DOCX files and produce a tracked-revision DOCX. |
+| `word consolidate` | Combine multiple DOCX revisions into one tracked-changes DOCX. |
+| `word accept-revisions` | Accept all tracked revisions in a DOCX file. |
+| `word simplify-markup` | Remove non-content markup from a DOCX file. |
+| `word verify` | Validate a DOCX — schema and relationships. |
+| `word to-html` | Convert a DOCX to HTML/CSS. |
+| `word from-html` | Convert HTML/CSS to a DOCX. |
+| `excel to-html` | Convert an XLSX sheet, range, or table to HTML/CSS. |
+| `excel create` | Generate an `.xlsx` workbook from a JSON workbook definition. |
+| `excel verify` | Validate an XLSX — schema and relationships. |
+| `install --skills` | Install Clippit workspace skills into the current workspace. |
+| `version` | Print version information. |
 
 ### Common flags
 


### PR DESCRIPTION
This PR adds a new "`clippit install --skills`" command that installs bundled Clippit workspace skills into project-local assistant directories.

## What's new

- **`clippit install --skills`** installs to `.agents/skills/clippit` (OpenCode/Pi).
- **`--skills=claude`** installs to `.claude/skills/clippit`.
- **`--skills=all`** installs to both targets.
- **`--dry-run`** previews the planned `SKILL.md` paths in JSON or text.

## Design notes

- Skill files are embedded as assembly resources, so the command works identically for:
  - `dotnet tool install`
  - NativeAOT single-file binaries distributed via npm
  - local development
- Installation is idempotent: re-running the command deletes the target skill directory and writes fresh bundled files. Any stale or locally modified skill content is replaced, matching the expectation that bundled skills are managed by the CLI.
- Output follows the existing CLI contract: success payloads to stdout, errors to stderr as compact JSON.

## Tests & schemas

- Integration tests cover default/explicit/all targets, idempotency, dry-run, and cleanup of modified/extra files.
- JSON contract tests validate both the install result and the dry-run plan against new schemas.
- `./build.sh` and `dotnet csharpier check .` pass locally.

## Docs & versions

- Updated `docs/cli.md`, `Clippit.Cli/README.md`, `npm/clippit/README.md", and `README.md`.
- Added `docs/schemas/install-result.v1.json` and `docs/schemas/install-plan.v1.json`.
- Bumped `Clippit.Cli` to **0.8.0** and the `Clippit` library to **3.8.0** in the changelogs.

Closes the workspace-skill install feature.
